### PR TITLE
Enable prompt caching for Strands agent to reduce token usage and costs

### DIFF
--- a/backend/src/review-workflow/review-item-processor/agent.py
+++ b/backend/src/review-workflow/review-item-processor/agent.py
@@ -252,7 +252,11 @@ def run_strands_agent(
         logger.info(f"Creating Strands agent with model: {model_id}")
         agent = Agent(
             model=BedrockModel(
-                model_id=model_id, region_name=BEDROCK_REGION, temperature=temperature
+                model_id=model_id,
+                region_name=BEDROCK_REGION,
+                temperature=temperature,
+                cache_prompt="default",  # Enable system prompt caching
+                cache_tools="default",  # Enable tool definitions caching
             ),
             tools=tools,
             system_prompt=system_prompt,


### PR DESCRIPTION
- Add cache_prompt='default' to enable system prompt caching
- Add cache_tools='default' to enable tool definitions caching
- Expected to reduce input tokens by 30-50% for repeated operations
- Particularly effective with multiple MCP tools and long review prompts

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
