### PR TITLE
fix: add "RAPID" to README titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Review & Assessment Powered by Intelligent Documentation
+# Review & Assessment Powered by Intelligent Documentation (RAPID)
 
 [English](./docs/en/README_en.md) | [日本語](README.md)
 

--- a/docs/en/README_en.md
+++ b/docs/en/README_en.md
@@ -1,4 +1,4 @@
-# Review & Assessment Powered by Intelligent Documentation
+# Review & Assessment Powered by Intelligent Documentation (RAPID)
 
 [English](README_en.md) | [日本語](../../README.md)
 


### PR DESCRIPTION
This PR adds "RAPID" after the title "Review & Assessment Powered by Intelligent Documentation" in both README files (Japanese and English), as requested in issue #28.

Resolves #28

Generated with [Claude Code](https://claude.ai/code)