### PR TITLE
Fix: Correct supported file format displays

### DIFF
--- a/frontend/src/components/FormFileUpload.tsx
+++ b/frontend/src/components/FormFileUpload.tsx
@@ -12,6 +12,7 @@ interface FormFileUploadProps {
   className?: string;
   uploadedDocuments?: Array<{ documentId: string; filename: string }>;
   onDeleteFile?: (index: number) => void;
+  acceptedFileTypes?: Record<string, string[]>;
 }
 
 /**
@@ -29,6 +30,7 @@ export const FormFileUpload: React.FC<FormFileUploadProps> = ({
   className = "",
   uploadedDocuments = [],
   onDeleteFile,
+  acceptedFileTypes,
 }) => {
   return (
     <div className={`mb-6 ${className}`}>
@@ -42,6 +44,7 @@ export const FormFileUpload: React.FC<FormFileUploadProps> = ({
         multiple={multiple}
         uploadedDocuments={uploadedDocuments}
         onDeleteFile={onDeleteFile}
+        acceptedFileTypes={acceptedFileTypes}
       />
       {error && <p className="mt-1 text-red text-sm">{error}</p>}
     </div>

--- a/frontend/src/features/checklist/pages/CreateChecklistPage.tsx
+++ b/frontend/src/features/checklist/pages/CreateChecklistPage.tsx
@@ -243,6 +243,9 @@ export function CreateChecklistPage() {
             multiple={false}
             uploadedDocuments={uploadedDocuments || []}
             onDeleteFile={handleFileRemove}
+            acceptedFileTypes={{
+              'application/pdf': ['.pdf']
+            }}
           />
 
           {/* プロンプトテンプレート選択セクション */}

--- a/frontend/src/features/review/pages/CreateReviewPage.tsx
+++ b/frontend/src/features/review/pages/CreateReviewPage.tsx
@@ -335,6 +335,10 @@ export const CreateReviewPage: React.FC = () => {
                 multiple={fileType === REVIEW_FILE_TYPE.IMAGE}
                 uploadedDocuments={uploadedDocuments}
                 onDeleteFile={handleFileRemove}
+                acceptedFileTypes={fileType === REVIEW_FILE_TYPE.PDF ? 
+                  { 'application/pdf': ['.pdf'] } : 
+                  { 'image/png': ['.png'], 'image/jpeg': ['.jpg', '.jpeg'] }
+                }
               />
             </div>
 


### PR DESCRIPTION
This PR fixes the display of supported file formats in different contexts:

- Checklist creation: Now only displays PDF as supported
- Review creation: Dynamically changes supported formats based on selected tab (PDF or images)

Closes #32

Generated with [Claude Code](https://claude.ai/code)