### PR TITLE
fix: remove duplicated stack description

### DIFF
--- a/cdk/bin/rapid.ts
+++ b/cdk/bin/rapid.ts
@@ -36,8 +36,6 @@ new RapidStack(app, "RapidStack", {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION || "us-west-2",
   },
-  description:
-    "RAPID (Review & Assessment Powered by Intelligent Documentation)",
   crossRegionReferences: true,
   webAclId: waf.webAclArn.value,
   enableIpV6: waf.ipV6Enabled,


### PR DESCRIPTION
This PR removes the duplicated stack description from cdk/bin/rapid.ts, as it's already defined in cdk/lib/rapid-stack.ts.

Resolves #45

Generated with [Claude Code](https://claude.ai/code)