### PR TITLE
Fix Docker Hub rate limiting by using Amazon ECR Public

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 node:22
+FROM --platform=linux/arm64 public.ecr.aws/docker/library/node:22
 # Lambda Web Adapter を追加
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.0 /lambda-adapter /opt/extensions/lambda-adapter
 


### PR DESCRIPTION
- Replace 'FROM node:22' with 'FROM public.ecr.aws/docker/library/node:22'
- Resolves deployment failures due to Docker Hub IP-based rate limiting
- Fixes issue #49

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
