### PR TITLE
Add chmod +x bin.sh instructions to deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
    ```bash
    git clone https://github.com/aws-samples/review-and-assessment-powered-by-intelligent-documentation.git
    cd review-and-assessment-powered-by-intelligent-documentation
+   chmod +x bin.sh
    ./bin.sh
    ```
 

--- a/docs/en/README_en.md
+++ b/docs/en/README_en.md
@@ -59,6 +59,7 @@ This method allows you to deploy directly from your browser using AWS CloudShell
    ```bash
    git clone https://github.com/aws-samples/review-and-assessment-powered-by-intelligent-documentation.git
    cd review-and-assessment-powered-by-intelligent-documentation
+   chmod +x bin.sh
    ./bin.sh
    ```
 


### PR DESCRIPTION
Added `chmod +x bin.sh` instructions to the deployment section in both Japanese and English README files for easy deployment.

Resolves #53

Generated with [Claude Code](https://claude.ai/code)