### PR TITLE
Fix i18n missing translations for checklist edit modal and document preview

### DIFF
--- a/frontend/src/components/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentPreview.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { usePresignedDownloadUrl } from "../hooks/usePresignedDownloadUrl";
 import Spinner from "./Spinner";
 import { HiExternalLink } from "react-icons/hi";
@@ -14,6 +15,7 @@ export default function DocumentPreview({
   filename,
   pageNumber,
 }: DocumentPreviewProps) {
+  const { t } = useTranslation();
   const [url, setUrl] = useState<string | null>(null);
   const { getPresignedUrl, getPdfPageUrl, isLoading, error } =
     usePresignedDownloadUrl();
@@ -42,7 +44,7 @@ export default function DocumentPreview({
 
   if (error) {
     return (
-      <div className="text-red-500">ドキュメントのURLの取得に失敗しました</div>
+      <div className="text-red-500">{t("common.documentUrlError")}</div>
     );
   }
 
@@ -59,7 +61,7 @@ export default function DocumentPreview({
         className="flex items-center text-aws-sea-blue hover:underline"
       >
         <span>{filename}</span>
-        {pageNumber && <span className="ml-1">（{pageNumber}ページ）</span>}
+        {pageNumber && <span className="ml-1">{t("common.pageNumber", { page: pageNumber })}</span>}
         <HiExternalLink className="ml-1 h-4 w-4" />
       </a>
     </div>

--- a/frontend/src/features/checklist/components/CheckListItemEditModal.tsx
+++ b/frontend/src/features/checklist/components/CheckListItemEditModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import Modal from "../../../components/Modal";
 import Button from "../../../components/Button";
 import { CheckListItemEntity } from "../types";
@@ -23,6 +24,7 @@ export default function CheckListItemEditModal({
   checkListSetId,
   onSuccess,
 }: CheckListItemEditModalProps) {
+  const { t } = useTranslation();
   const [formData, setFormData] = useState({
     name: item.name,
     description: item.description || "",
@@ -52,7 +54,7 @@ export default function CheckListItemEditModal({
     e.preventDefault();
 
     if (!formData.name.trim()) {
-      setError("名前は必須です");
+      setError(t("checklist.editItemNameRequired"));
       return;
     }
 
@@ -63,13 +65,13 @@ export default function CheckListItemEditModal({
         name: formData.name,
         description: formData.description,
       });
-      addToast("チェックリスト項目を更新しました", "success");
+      addToast(t("checklist.editItemUpdateSuccess"), "success");
       onSuccess();
       onClose();
     } catch (err) {
       console.error("項目の更新に失敗しました", err);
-      setError("項目の更新に失敗しました。もう一度お試しください。");
-      addToast("チェックリスト項目の更新に失敗しました", "error");
+      setError(t("checklist.editItemUpdateError"));
+      addToast(t("checklist.editItemUpdateErrorToast"), "error");
     } finally {
       setIsSubmitting(false);
     }
@@ -79,7 +81,7 @@ export default function CheckListItemEditModal({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      title="チェックリスト項目の編集"
+      title={t("checklist.editItemTitle")}
       size="md">
       <form onSubmit={handleSubmit}>
         {error && (
@@ -92,7 +94,7 @@ export default function CheckListItemEditModal({
           <label
             htmlFor="name"
             className="mb-2 block font-medium text-aws-squid-ink-light">
-            名前 <span className="text-red">*</span>
+            {t("checklist.name")} <span className="text-red">*</span>
           </label>
           <input
             type="text"
@@ -107,7 +109,7 @@ export default function CheckListItemEditModal({
             required
           />
           {!formData.name.trim() && (
-            <p className="mt-1 text-sm text-red">名前は必須です</p>
+            <p className="mt-1 text-sm text-red">{t("checklist.editItemNameRequired")}</p>
           )}
         </div>
 
@@ -115,7 +117,7 @@ export default function CheckListItemEditModal({
           <label
             htmlFor="description"
             className="mb-2 block font-medium text-aws-squid-ink-light">
-            説明
+            {t("common.description")}
           </label>
           <textarea
             id="description"
@@ -130,10 +132,10 @@ export default function CheckListItemEditModal({
 
         <div className="mt-6 flex justify-end space-x-3">
           <Button outline onClick={onClose} type="button">
-            キャンセル
+            {t("common.cancel")}
           </Button>
           <Button variant="primary" type="submit" disabled={isSubmitting}>
-            {isSubmitting ? "更新中..." : "更新"}
+            {isSubmitting ? t("checklist.editItemUpdating") : t("checklist.editItemUpdate")}
           </Button>
         </div>
       </form>

--- a/frontend/src/features/checklist/components/CheckListItemTreeNode.tsx
+++ b/frontend/src/features/checklist/components/CheckListItemTreeNode.tsx
@@ -90,9 +90,9 @@ export default function CheckListItemTreeNode({
   const handleDelete = () => {
     if (!isEditable) return;
 
-    showConfirm(`「${item.name}」を本当に削除しますか？`, {
+    showConfirm(t("checklist.deleteItemConfirmation", { name: item.name }), {
       title: t("common.confirm"),
-      confirmButtonText: "削除",
+      confirmButtonText: t("common.delete"),
       onConfirm: async () => {
         try {
           await deleteCheckListItem(item.id);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -32,7 +32,9 @@
     "warning": "Warning",
     "confirmation": "Confirmation",
     "previous": "Previous",
-    "description": "Description"
+    "description": "Description",
+    "documentUrlError": "Failed to get document URL",
+    "pageNumber": "(Page {{page}})"
   },
   "pagination": {
     "showing": "Showing",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -31,7 +31,8 @@
     "info": "Info",
     "warning": "Warning",
     "confirmation": "Confirmation",
-    "previous": "Previous"
+    "previous": "Previous",
+    "description": "Description"
   },
   "pagination": {
     "showing": "Showing",
@@ -132,7 +133,15 @@
     "itemNamePlaceholder": "Checklist item name",
     "itemDescriptionPlaceholder": "Checklist item description",
     "add": "Add",
-    "itemAddError": "Failed to save checklist item"
+    "itemAddError": "Failed to save checklist item",
+    "editItemTitle": "Edit Checklist Item",
+    "editItemNameRequired": "Name is required",
+    "editItemUpdateSuccess": "Checklist item updated successfully",
+    "editItemUpdateError": "Failed to update item. Please try again.",
+    "editItemUpdateErrorToast": "Failed to update checklist item",
+    "editItemUpdating": "Updating...",
+    "editItemUpdate": "Update",
+    "deleteItemConfirmation": "Are you sure you want to delete \"{{name}}\"?"
   },
   "review": {
     "title": "Review Jobs",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -32,7 +32,9 @@
     "warning": "警告",
     "confirmation": "確認",
     "previous": "前へ",
-    "description": "説明"
+    "description": "説明",
+    "documentUrlError": "ドキュメントのURLの取得に失敗しました",
+    "pageNumber": "（{{page}}ページ）"
   },
   "pagination": {
     "showing": "表示中",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -31,7 +31,8 @@
     "info": "情報",
     "warning": "警告",
     "confirmation": "確認",
-    "previous": "前へ"
+    "previous": "前へ",
+    "description": "説明"
   },
   "pagination": {
     "showing": "表示中",
@@ -132,7 +133,15 @@
     "itemNamePlaceholder": "チェック項目の名前",
     "itemDescriptionPlaceholder": "チェック項目の説明",
     "add": "追加",
-    "itemAddError": "チェックリスト項目の保存に失敗しました"
+    "itemAddError": "チェックリスト項目の保存に失敗しました",
+    "editItemTitle": "チェックリスト項目の編集",
+    "editItemNameRequired": "名前は必須です",
+    "editItemUpdateSuccess": "チェックリスト項目を更新しました",
+    "editItemUpdateError": "項目の更新に失敗しました。もう一度お試しください。",
+    "editItemUpdateErrorToast": "チェックリスト項目の更新に失敗しました",
+    "editItemUpdating": "更新中...",
+    "editItemUpdate": "更新",
+    "deleteItemConfirmation": "「{{name}}」を本当に削除しますか？"
   },
   "review": {
     "title": "審査ジョブ一覧",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes missing i18n translations in the checklist item edit modal and document preview component.

### Changes:
* Add i18n support to CheckListItemEditModal component (title, labels, buttons, error messages)
* Fix delete confirmation dialog in CheckListItemTreeNode 
* Add i18n support to DocumentPreview component (page number display, error messages)
* Add corresponding translation keys for both Japanese and English locales

### Testing:
* Verified relevant hardcoded Japanese strings are now properly localized
* Confirmed proper display in both Japanese and English language settings

[Before this fix]
Some items are displayed in Japanese in English language setting
<img width="459" height="483" alt="image" src="https://github.com/user-attachments/assets/82477b54-5591-42f6-9631-474e2fccf407" />

[After fix]
Items are displayed in configured language, both in Japanese and English
<img width="466" height="236" alt="image" src="https://github.com/user-attachments/assets/812a8821-295f-4d82-a742-a3c7de9b7c4f" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
