### PR TITLE
ユーザアカウント表示部分をuser_name(uuid)からemailを優先するように変更

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -159,7 +159,7 @@ export default function Sidebar() {
                 <div className="mb-2 flex items-center">
                   <HiUser className="mr-2 h-5 w-5" />
                   <span className="truncate text-sm">
-                    {user.username || user.email}
+                    { user.email || user.username}
                   </span>
                 </div>
                 <button


### PR DESCRIPTION
## 変更内容
 
サイドバーのユーザアカウント表示を user_name(uuid) から email を優先して表示するように変更しました。
- frontend/src/components/Sidebar.tsxのサイドバー表示ロジックを修正し、表示順を「email があれば email を表示 → なければ既存の user_name(uuid) を表示」としました。
 
## 変更理由
 
メールアドレスはユーザーが自身を識別しやすく（ログインユーザーの確認やサポート時の振り分け等）、UI上の視認性が向上するため優先表示としています。
 
## 関連Issue
 
[#70: ログイン後のユーザーID表示部分はメールアドレスになると良い](https://github.com/aws-samples/review-and-assessment-powered-by-intelligent-documentation/issues/70)
