### PR TITLE
fix: exclude invoke-agent Lambda from CDK tsc build (fixes fresh-checkout TS2307)

### DIFF
--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -26,6 +26,7 @@
   },
   "exclude": [
     "node_modules",
-    "cdk.out"
+    "cdk.out",
+    "lib/constructs/lambda/invoke-agent"
   ]
 }


### PR DESCRIPTION
## Issue
Fixes #281

## Description

On a fresh checkout, `cd cdk && npm run deploy` (or `npm ci && npm run build`) fails:

```
lib/constructs/lambda/invoke-agent/index.ts:1:25 - error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations.
lib/constructs/lambda/invoke-agent/index.ts:5:8 - error TS2307: Cannot find module '@aws-sdk/client-bedrock-agentcore' or its corresponding type declarations.
```

Commit `7b834a7` removed the `postinstall`/`build:lambda` scripts that used to install the nested `node_modules` for `lib/constructs/lambda/invoke-agent/` — correct, since that Lambda is bundled by esbuild (`NodejsFunction`) at synth time. But `cdk/tsconfig.json` still lets the top-level `tsc` type-check the Lambda's `index.ts`, whose dependencies (`@types/aws-lambda`, `@aws-sdk/client-bedrock-agentcore`) are only declared in the nested `package.json`, so module resolution fails.

This PR adds `lib/constructs/lambda/invoke-agent` to the `exclude` list in `cdk/tsconfig.json`, matching the esbuild-at-synth design. The Lambda keeps its own `tsconfig.json` for editor support, and esbuild continues to compile it during synth.

## Verification

- `cd cdk && npm run build` passes on a fresh checkout (previously failed with the 4 errors above)
- `npx cdk synth` succeeds; the invoke-agent Lambda bundles correctly (`index.mjs 3.5kb`)
- Full `npm run deploy` completed successfully against a live account

Note: this regression wasn't caught by CI because the cdk jobs run only `cdk synth` and `jest`, never `tsc`. Happy to add a `npm run build` step to the cdk CI job in this PR if desired.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.