### PR TITLE
[Major Update 2/17] feat(agent): upgrade AgentCore runtime and refresh model lineup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Refreshed the model lineup: Claude Sonnet 5 (Global) and Claude Opus 4.8 / 4.7 (Global and JP inference profiles) joined `availableModels`, Claude Sonnet 4.6 and Claude Haiku 4.5 gained JP profiles, Claude Sonnet 4 (Global) left the bundled list, and the app-wide default model is now Claude Sonnet 5 (Global).
+- Frontend test infrastructure (vitest, jsdom, fast-check) with an `npm test` entry point.
 
 ### Changed
 
 - Refreshed package dependencies across backend, frontend, CDK, and the UC008 example CDK app.
 - Restructured the documentation (EN/JA): deployment options and local development moved into dedicated guides, and the README gained a document navigation table and "How It Works" / "Key Features" sections (content-neutral moves).
 - Stopped tracking `cdk/outputs.json` (a deploy-time output) and reorganized `.gitignore`.
+- **Breaking (CDK parameters):** consolidated `documentProcessingModelId` / `imageReviewModelId` into a single `defaultModelId`. The old parameter names and the CloudShell `--document-model` / `--image-model` flags remain accepted as deprecated aliases. Amazon Bedrock now runs in the region where the stack is deployed (one legacy exception: the experimental Feedback Aggregator keeps using the old `bedrockRegion` value until that construct is removed).
+- Upgraded the review agent runtime (bedrock-agentcore SDK 1.18, refreshed Strands Agents and tooling) and pinned the AgentCore idle session timeout to 900 seconds so long-running review items are no longer terminated mid-invocation (persistent `RuntimeClientError`).
+- Reduced backend workflow and agent logging to metadata on the normal path (item counts, response lengths, log level pinned to INFO) so successful runs do not write document contents to CloudWatch Logs in plain text (the AgentCore response body is still logged verbatim on non-200 calls, for failure diagnosis).
 
 ### Fixed
 
 - MCP tool preview and review-time MCP execution: stdio MCP servers launched with `uvx` (including the bundled `mcp-server-fetch` example) began dying on import before the handshake ("MCP error -32000: Connection closed") once MCP Python SDK 2.0.0 (2026-07-28, a breaking rework) was released, because many servers declare no upper bound on `mcp`; both container images now ship `mcp-uv-constraints.txt` and constrain uv/uvx dependency resolution to `mcp<2` (remove the constraint once the ecosystem has migrated to 2.x).
 - Getting started: the README now runs `npm ci` in `cdk/` before `npx cdk bootstrap` (bootstrapping loads the CDK app, so the documented command failed on a fresh clone without installing the CDK dependencies first), and the local development guide now syncs the optional `dev` extra before `uv run pytest` (a plain `uv sync` does not install it, so pytest could not start).
+
+### Security
+
+- Hardened the review agent's file-access tool so it can only read files inside the review's own workspace (path-traversal / local-file-inclusion prevention), and added an environment-variable blocklist and stricter configuration validation for MCP tools.
 
 ## [1.25.2] - 2026-07-01
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Concrete scenarios with sample documents are available in the [examples gallery]
 
 This method allows you to deploy directly from your browser using AWS CloudShell, without preparing a local environment.
 
-1. **Enable Amazon Bedrock models**
+1. **Confirm the models to use with Amazon Bedrock**
 
-   Access Bedrock Model Access from the AWS Management Console and enable access to the models you plan to use (see [AI Model Customization](./docs/en/deployment-options.md#ai-model-customization) for the model list). By default, the Oregon (us-west-2) region is used for Amazon Bedrock, but you can change it with the `--bedrock-region` option.
+   Amazon Bedrock uses the region where the stack is deployed (the region in which you open AWS CloudShell). Make sure the target models (inference profiles) are enabled in that region. To use cross-region (`global.` / `us.` / `eu.` / `apac.` / `jp.`) inference profiles, see [AI Model Customization](./docs/en/deployment-options.md#ai-model-customization).
 
 2. **Open AWS CloudShell**
 
@@ -183,9 +183,10 @@ The following parameters can be customized during CDK deployment. Edit [`cdk/lib
 |                           | cognitoDomainPrefix                  | Prefix for the Cognito domain                                                                                                                                              | Auto-generated                             |
 |                           | cognitoSelfSignUpEnabled             | Whether to enable self-signup for the Cognito User Pool                                                                                                                    | true (enabled)                             |
 | **Migration**             | autoMigrate                          | Whether to automatically run database migration during deployment                                                                                                          | true (auto-run)                            |
+| **Bedrock**               | defaultModelId                  | The default AI model used across the whole app (document processing, image review, checklist generation, ambiguity detection, and the WebUI default); per-item selections from `availableModels` override it.                                                    | global.anthropic.claude-sonnet-5           |
+|                           | availableModels                 | List of models available for per-checklist-item model selection. Model IDs must use an inference-profile prefix (`global.` / `jp.` etc.) that matches the deployment region; see [AI Model Customization](./docs/en/deployment-options.md#ai-model-customization). Set `[]` to hide the model selection UI. | Sonnet 5 (Global), Opus 4.8 / 4.7, Sonnet 4.6, Haiku 4.5 (Global & JP), plus Opus 4.6 (Global) |
 | **MCP Features**          | mcpAdmin                             | Whether to grant admin permissions to the MCP runtime Lambda function                                                                                                      | false (disabled)                           |
 | **Citations API**         | enableCitations                      | Whether to enable the Citations API for PDF documents ([AWS announcement](https://aws.amazon.com/about-aws/whats-new/2025/06/citations-api-pdf-claude-models-amazon-bedrock/)) | true (enabled)                             |
-| **Model Selection**       | availableModels                      | List of models available for per-checklist-item model selection. Set to an empty array `[]` to disable the model selection UI                                              | Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5, Claude Sonnet 4 |
 | **Network Mode**          | s3ApiGatewayFrontend                 | Serve the SPA from S3 via a dedicated REGIONAL API Gateway (S3 proxy) instead of CloudFront, keeping standard networking. See [Closed / Private Network Deployment](#closed--private-network-deployment). | false                                      |
 |                           | closedNetwork                        | Fully private mode: isolated subnets, no NAT, VPC endpoints, PRIVATE API Gateways, Cognito PrivateLink. Implies `s3ApiGatewayFrontend`. See [Closed / Private Network Deployment](#closed--private-network-deployment). | false                                      |
 |                           | agentCoreNetworkMode                 | AgentCore Runtime network mode (only applies when `closedNetwork`). `PUBLIC` = runtime has internet (MCP/uv work); `VPC` = runtime fully isolated. Invoke path is private either way | PUBLIC                                     |
@@ -218,24 +219,19 @@ Closed network mode comes with several constraints — deployment itself still r
 
 ### AI Model Customization
 
-RAPID uses Strands agents with tools such as file reading, so you must select **models that support tool use**. You can change the processing models (`documentProcessingModelId` / `imageReviewModelId`) and the per-item selection list (`availableModels`) in `parameter.ts`. For the list of tool-use capable models, notes on cross-region inference profiles, and configuration examples, see [AI Model Customization](./docs/en/deployment-options.md#ai-model-customization).
+RAPID uses Strands agents with tools such as file reading, so you must select **models that support tool use**. You can change the app-wide default model (`defaultModelId`) and the per-item selection list (`availableModels`) in `parameter.ts`; when a checklist item has no model selected, the review falls back to the default model. For the list of bundled models, notes on regions and inference profiles, configuration examples, and how to register token prices when adding a model, see [AI Model Customization](./docs/en/deployment-options.md#ai-model-customization).
 
 ## Pricing
 
 This solution incurs infrastructure fixed costs (~$5/day, ~$150/month, mainly for the NAT Gateway and Aurora Serverless v2) plus Amazon Bedrock usage costs based on document processing volume (pay-per-use).
 
-| Model class                                                | Processable pages per review | Cost example         |
-| ---------------------------------------------------------- | ---------------------------- | -------------------- |
-| Budget-friendly lightweight model (Claude Haiku 4.5, etc.) | ~80–85 pages                 | ~$0.28 for 80 pages  |
-| High-accuracy large-capacity model (Claude Opus 4.6, etc.) | ~430 pages                   | ~$5.75 for 400 pages |
+| Model class                                              | Max pages per review (context-window guide) | Cost example            |
+| -------------------------------------------------------- | ------------------------------------------- | ----------------------- |
+| Budget-friendly lightweight model (Claude Haiku 4.5, etc.) | ~80–85 pages                                | ~$0.28 for 80 pages     |
+| High-accuracy large-capacity model (Claude Opus 4.x, etc.) | ~430 pages                                  | ~$5.75 for 400 pages    |
 
 > [!Important]
-> - **Please test with your own sample documents to determine actual costs.** Costs vary significantly with text volume, image count / size, and the number of checklist items (page counts are rough estimates only).
-> - **Agent features** (Knowledge Bases, Code Interpreter, etc.) may incur up to 10x higher costs.
-> - Detailed pricing and token usage can be viewed on the review results screen.
-> - The Amazon Bedrock Converse API has a 4.5 MB file size limit.
->
-> For the latest pricing information, please visit the [Amazon Bedrock pricing page](https://aws.amazon.com/bedrock/pricing/).
+> Please test with your own sample documents: costs vary significantly with text volume, image count / size, the number of checklist items, and tool usage (Knowledge Bases, Code Interpreter, etc.). The cost shown on the review results screen is an estimate based only on that review's token usage and may not match your actual charges.
 
 ## User Roles and Admin Setup
 

--- a/backend/src/api/features/checklist/domain/service/ambiguity-detector.ts
+++ b/backend/src/api/features/checklist/domain/service/ambiguity-detector.ts
@@ -8,10 +8,12 @@ import {
 } from "../model/checklist";
 import { makePrismaUserPreferenceRepository } from "../../../user-preference/domain/repository";
 
-const BEDROCK_REGION = process.env.BEDROCK_REGION || "us-west-2";
+// 既定モデルを Claude Sonnet 5 (Global) に統一。通常は Worker Lambda に
+// DOCUMENT_PROCESSING_MODEL_ID env が注入される（ambiguity-detection-processor.ts）ため
+// この fallback は保険。他の処理経路（document-processing / review）と既定モデルを揃える。
 const MODEL_ID =
   process.env.DOCUMENT_PROCESSING_MODEL_ID ||
-  "global.anthropic.claude-sonnet-4-6";
+  "global.anthropic.claude-sonnet-5";
 
 const getAmbiguityDetectionPrompt = (
   languageName: string,
@@ -87,7 +89,8 @@ export const detectAmbiguity = async (params: {
   };
   const languageName = languageMap[userLanguage] || "English";
 
-  const bedrockClient = new BedrockRuntimeClient({ region: BEDROCK_REGION });
+  // region はデプロイ先（Lambda 実行）リージョンを自動利用する
+  const bedrockClient = new BedrockRuntimeClient({});
 
   const prompt = `${getAmbiguityDetectionPrompt(languageName, checklistContext)}
 

--- a/backend/src/checklist-workflow/document-processing/llm-processing.ts
+++ b/backend/src/checklist-workflow/document-processing/llm-processing.ts
@@ -19,18 +19,33 @@ import { ParsedChecklistItem, ProcessWithLLMResult } from "../common/types";
 import { getLanguageName, DEFAULT_LANGUAGE } from "../../utils/language";
 import { ulid } from "ulid";
 
-// Define model ID with environment variable override
-const DEFAULT_MODEL_ID = "global.anthropic.claude-sonnet-4-6";
-const MODEL_ID = process.env.DOCUMENT_PROCESSING_MODEL_ID || DEFAULT_MODEL_ID;
+// Default extraction model used when neither a per-request modelId nor the
+// DOCUMENT_PROCESSING_MODEL_ID environment variable is provided.
+const DEFAULT_MODEL_ID = "global.anthropic.claude-sonnet-5"; // Sonnet 5 (Global)
 
-// Log model configuration
-if (process.env.DOCUMENT_PROCESSING_MODEL_ID) {
-  console.info(`Using custom document processing model: ${MODEL_ID}`);
-} else {
-  console.info(`Using default document processing model: ${MODEL_ID}`);
+/**
+ * Resolve the model ID to use for checklist extraction.
+ *
+ * Resolution order (additive / backward compatible):
+ *  1. Non-empty `passedModelId` (per-request override from the workflow) wins.
+ *  2. Otherwise, fall back to a non-empty `envModelId`
+ *     (DOCUMENT_PROCESSING_MODEL_ID), preserving the existing env default.
+ *  3. Otherwise, fall back to the fixed `DEFAULT_MODEL_ID`.
+ *
+ * Always returns a non-empty string and never throws.
+ */
+export function resolveExtractionModelId(
+  passedModelId: string | null | undefined,
+  envModelId: string | null | undefined
+): string {
+  if (typeof passedModelId === "string" && passedModelId.length > 0) {
+    return passedModelId;
+  }
+  if (typeof envModelId === "string" && envModelId.length > 0) {
+    return envModelId;
+  }
+  return DEFAULT_MODEL_ID;
 }
-
-const BEDROCK_REGION = process.env.BEDROCK_REGION || "us-west-2";
 
 // Helper function to get the checklist extraction prompt based on language
 export const getChecklistExtractionPrompt = (language: string) => {
@@ -110,6 +125,7 @@ export interface ProcessWithLLMParams {
   documentId: string;
   pageNumber: number;
   userId?: string; // Optional user ID for language preference
+  modelId?: string | null; // Optional per-request extraction model override
 }
 
 /**
@@ -121,10 +137,20 @@ export async function processWithLLM({
   documentId,
   pageNumber,
   userId,
+  modelId,
 }: ProcessWithLLMParams): Promise<ProcessWithLLMResult> {
   const s3Client = new S3Client({});
-  const bedrockClient = new BedrockRuntimeClient({ region: BEDROCK_REGION });
+  // region はデプロイ先（Lambda 実行）リージョンを自動利用する
+  const bedrockClient = new BedrockRuntimeClient({});
   const bucketName = process.env.DOCUMENT_BUCKET || "";
+
+  // Resolve the model for this invocation: per-request modelId wins, then the
+  // DOCUMENT_PROCESSING_MODEL_ID env default, then the fixed DEFAULT_MODEL_ID.
+  const effectiveModelId = resolveExtractionModelId(
+    modelId,
+    process.env.DOCUMENT_PROCESSING_MODEL_ID
+  );
+  console.info(`Using document processing model: ${effectiveModelId}`);
 
   // Get user preference for language if userId is provided
   let userLanguage = DEFAULT_LANGUAGE;
@@ -137,9 +163,10 @@ export async function processWithLLM({
         await makePrismaUserPreferenceRepository();
       const userPreference =
         await userPreferenceRepository.getUserPreference(userId);
+      // 文書由来の機微情報を CloudWatch に全文出力しないよう、
+      // language のみのメタログに縮小する。
       console.log(
-        `[DEBUG] User preference retrieved:`,
-        JSON.stringify(userPreference, null, 2)
+        `[DEBUG] User preference retrieved: language=${userPreference?.language ?? "(none)"}`
       );
 
       if (userPreference && userPreference.language) {
@@ -189,13 +216,13 @@ export async function processWithLLM({
   console.log(
     `[DEBUG] Final language used for checklist extraction: ${userLanguage}`
   );
-  console.log(`[DEBUG] Using model: ${MODEL_ID}`);
+  console.log(`[DEBUG] Using model: ${effectiveModelId}`);
   console.log(`[DEBUG] PDF size: ${pdfBytes.length} bytes`);
 
   const checklistExtractionPrompt = getChecklistExtractionPrompt(userLanguage);
 
   // Determine citations setting based on model type
-  const isNovaModel = MODEL_ID.includes("nova");
+  const isNovaModel = effectiveModelId.includes("nova");
   const citationsConfig = isNovaModel
     ? { enabled: false } // Disable citations for Nova models as they cause InternalServerException
     : { enabled: true }; // Keep enabled for Other models for PDF image analysis workaround
@@ -209,7 +236,7 @@ export async function processWithLLM({
   try {
     response = await bedrockClient.send(
       new ConverseCommand({
-        modelId: MODEL_ID,
+        modelId: effectiveModelId,
         messages: [
           {
             role: "user",
@@ -244,7 +271,7 @@ export async function processWithLLM({
     );
   } catch (error: any) {
     console.error(`[ERROR] Bedrock API call failed:`, error);
-    console.error(`[ERROR] Model ID: ${MODEL_ID}`);
+    console.error(`[ERROR] Model ID: ${effectiveModelId}`);
     console.error(`[ERROR] PDF size: ${pdfBytes.length} bytes`);
     console.error(`[ERROR] Citations enabled: ${citationsConfig.enabled}`);
     console.error(
@@ -288,8 +315,9 @@ export async function processWithLLM({
       const jsonText = extractJsonBlocks(llmResponse);
       checklistItems = JSON.parse(jsonText);
     }
+    // 抽出した文書内容（name/description 等）を平文ログに出さず、件数のみを記録する。
     console.log(
-      `Parsed LLM response as JSON: ${JSON.stringify(checklistItems, null, 2)}`
+      `Parsed LLM response as JSON: ${Array.isArray(checklistItems) ? checklistItems.length : 0} items`
     );
 
     // パース直後に各項目にIDを割り当て
@@ -298,10 +326,13 @@ export async function processWithLLM({
       id: ulid(),
     }));
   } catch (error) {
+    // 生の LLM レスポンス全文を出さず、文字数のみを記録する。
     console.error(
-      `[ERROR] JSON parsing failed: ${error}\nLLM response: ${llmResponse}`
+      `[ERROR] JSON parsing failed: ${error} (response length: ${llmResponse.length} characters)`
     );
-    console.error(`[ERROR] Starting retry process for model: ${MODEL_ID}`);
+    console.error(
+      `[ERROR] Starting retry process for model: ${effectiveModelId}`
+    );
 
     // If JSON parsing fails, send error message to Bedrock for retry
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -309,7 +340,7 @@ export async function processWithLLM({
     try {
       const retryResponse = await bedrockClient.send(
         new ConverseCommand({
-          modelId: MODEL_ID,
+          modelId: effectiveModelId,
           messages: [
             {
               role: "user",
@@ -360,8 +391,8 @@ export async function processWithLLM({
         checklistItems = JSON.parse(retryLlmResponse);
         console.log(`[DEBUG] Retry JSON parsing successful`);
       } catch (retryError) {
+        // 生の retry レスポンス全文ログを削除。
         console.error(`[ERROR] Retry JSON parsing also failed: ${retryError}`);
-        console.error(`[ERROR] Retry LLM response: ${retryLlmResponse}`);
         throw new Error(
           `Both initial and retry JSON parsing failed. Original error: ${errorMessage}, Retry error: ${retryError}`
         );
@@ -389,7 +420,10 @@ export async function processWithLLM({
     });
   }
 
-  console.log(`Response from LLM: ${JSON.stringify(checklistItems, null, 2)}`);
+  // 文書内容を平文ログに出さず、件数のみを記録する。
+  console.log(
+    `Response from LLM: ${Array.isArray(checklistItems) ? checklistItems.length : 0} items`
+  );
 
   const updatedChecklist = convertToUlid(checklistItems);
 

--- a/bin.sh
+++ b/bin.sh
@@ -31,6 +31,8 @@ S3_API_GATEWAY_FRONTEND="false"
 CLOSED_NETWORK="false"
 AGENT_CORE_NETWORK_MODE="PUBLIC"
 BEDROCK_REGION="us-west-2"
+DEFAULT_MODEL_ID=""
+# 後方互換（deprecated）: --document-model / --image-model は --default-model に統合済み
 DOCUMENT_PROCESSING_MODEL_ID=""
 IMAGE_REVIEW_MODEL_ID=""
 REPO_URL="https://github.com/aws-samples/review-and-assessment-powered-by-intelligent-documentation.git"
@@ -87,6 +89,10 @@ while [[ "$#" -gt 0 ]]; do
     ;;
   --bedrock-region)
     BEDROCK_REGION="$2"
+    shift
+    ;;
+  --default-model)
+    DEFAULT_MODEL_ID="$2"
     shift
     ;;
   --document-model)
@@ -173,8 +179,7 @@ aws cloudformation deploy \
   ClosedNetwork="$CLOSED_NETWORK" \
   AgentCoreNetworkMode="$AGENT_CORE_NETWORK_MODE" \
   BedrockRegion="$BEDROCK_REGION" \
-  DocumentProcessingModelId="$DOCUMENT_PROCESSING_MODEL_ID" \
-  ImageReviewModelId="$IMAGE_REVIEW_MODEL_ID" \
+  DefaultModelId="${DEFAULT_MODEL_ID:-${DOCUMENT_PROCESSING_MODEL_ID:-$IMAGE_REVIEW_MODEL_ID}}" \
   RepoUrl="$REPO_URL" \
   Branch="$BRANCH" \
   GitTag="$GIT_TAG"

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -7,40 +7,37 @@ The `cdk.json` file tells the CDK Toolkit how to execute the app.
 
 ## Deploy
 
-From a fresh checkout, `npm run deploy` builds all packages (backend and CDK)
-and deploys automatically. The review invoke-agent Lambda is compiled and
-bundled from TypeScript by esbuild during synth, so it needs no separate build
-step:
+From a fresh checkout, `npm run deploy` builds all packages (backend, the
+review invoke-agent Lambda, and CDK) and deploys automatically:
 
-```
+```bash
 cd cdk
-npx cdk bootstrap   # one-time per account/region
+npx cdk bootstrap
 npm run deploy
 ```
 
-> Note: `npm run deploy` uses the `review` AWS profile. If you use a different
-> profile, adjust the `deploy` script in `package.json` (or deploy manually,
-> see below).
+`npx cdk bootstrap` is required only once per account/region.
 
 ## Manual step-by-step deployment
 
 ```bash
-# Prepare the backend
 cd backend
 npm ci
 npm run prisma:generate
 npm run build
-
-# Install CDK packages and deploy
 cd ../cdk
 npm ci
 npx cdk deploy --require-approval never --all
 ```
 
+`npm ci` in `cdk/` also prepares the backend Prisma client (`preinstall`) and
+builds the invoke-agent Lambda (`postinstall`), so no extra build step is
+needed before `cdk deploy`.
+
 ## Other commands
 
 - `npm run build` compile CDK TypeScript to js (run `npm ci` first)
-- `npm run build:all` build backend + CDK (the invoke-agent Lambda is bundled by esbuild at synth time)
+- `npm run build:all` build backend + invoke-agent Lambda + CDK
 - `npm run watch` watch for changes and compile
 - `npm run test` run the jest unit tests
 - `npx cdk diff` compare deployed stack with current state

--- a/cdk/lib/constructs/agent.ts
+++ b/cdk/lib/constructs/agent.ts
@@ -11,15 +11,17 @@ import {
 } from "aws-cdk-lib/aws-iam";
 import { CfnMemory, CfnRuntime } from "aws-cdk-lib/aws-bedrockagentcore";
 
-import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as s3 from "aws-cdk-lib/aws-s3";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
 
 export interface AgentProps {
-  bedrockRegion: string;
   documentBucket: s3.IBucket;
   tempBucket: s3.IBucket;
-  documentProcessingModelId: string;
-  imageReviewModelId: string;
+  /**
+   * 既定の AI モデル ID。ドキュメント用・画像用の
+   * 2 つを 1 つに統合した（AgentCore Runtime へは互換のため両 env キーに供給）。
+   */
+  defaultModelId: string;
   enableCitations: boolean;
   enableCodeInterpreter: boolean;
   /**
@@ -44,11 +46,9 @@ export class Agent extends Construct {
     super(scope, id);
 
     const {
-      bedrockRegion,
       documentBucket,
       tempBucket,
-      documentProcessingModelId,
-      imageReviewModelId,
+      defaultModelId,
       enableCitations,
       enableCodeInterpreter,
       vpc,
@@ -205,6 +205,11 @@ export class Agent extends Construct {
       }),
     );
 
+    // Knowledge Base（RAG）ツール向けの bedrock:Retrieve 権限。
+    // Knowledge Base の設定は Web UI の「ツール設定」画面から行い、本アプリケーションと
+    // 同一の AWS アカウント・同一リージョンに存在する Knowledge Base を利用します。
+    // そのため Retrieve は当該アカウント・当該リージョンの knowledge-base/* に限定して
+    // 許可し、他アカウント・他リージョンの Knowledge Base は対象外とします。
     role.addToPolicy(
       new PolicyStatement({
         sid: "BedrockKnowledgeBaseAccess",
@@ -225,35 +230,7 @@ export class Agent extends Construct {
       }),
     );
 
-    // Network mode: VPC (closed mode) when a vpc is provided, otherwise PUBLIC.
-    // In VPC mode the runtime reaches Bedrock/S3/logs/etc. via the VPC endpoints.
-    let networkConfiguration: CfnRuntime.NetworkConfigurationProperty;
-    if (vpc) {
-      if (!subnetSelection) {
-        throw new Error(
-          "Agent: subnetSelection is required when vpc is provided (VPC network mode)",
-        );
-      }
-
-      const agentSg = new ec2.SecurityGroup(this, "RuntimeSecurityGroup", {
-        vpc,
-        description: "Security group for the AgentCore runtime (VPC mode)",
-        allowAllOutbound: true,
-      });
-      this.securityGroup = agentSg;
-
-      const selectedSubnets = vpc.selectSubnets(subnetSelection);
-      networkConfiguration = {
-        networkMode: "VPC",
-        networkModeConfig: {
-          subnets: selectedSubnets.subnetIds,
-          securityGroups: [agentSg.securityGroupId],
-        },
-      };
-    } else {
-      networkConfiguration = { networkMode: "PUBLIC" };
-    }
-
+    // Note: currently memory is not used
     const memory = new CfnMemory(this, "Memory", {
       name: Names.uniqueResourceName(this, { maxLength: 40 }),
       eventExpiryDuration: 30,
@@ -303,6 +280,35 @@ export class Agent extends Construct {
       }),
     );
 
+    // Network mode: VPC (closed mode) when a vpc is provided, otherwise PUBLIC.
+    // In VPC mode the runtime reaches Bedrock/S3/logs/etc. via the VPC endpoints.
+    let networkConfiguration: CfnRuntime.NetworkConfigurationProperty;
+    if (vpc) {
+      if (!subnetSelection) {
+        throw new Error(
+          "Agent: subnetSelection is required when vpc is provided (VPC network mode)",
+        );
+      }
+
+      const agentSg = new ec2.SecurityGroup(this, "RuntimeSecurityGroup", {
+        vpc,
+        description: "Security group for the AgentCore runtime (VPC mode)",
+        allowAllOutbound: true,
+      });
+      this.securityGroup = agentSg;
+
+      const selectedSubnets = vpc.selectSubnets(subnetSelection);
+      networkConfiguration = {
+        networkMode: "VPC",
+        networkModeConfig: {
+          subnets: selectedSubnets.subnetIds,
+          securityGroups: [agentSg.securityGroupId],
+        },
+      };
+    } else {
+      networkConfiguration = { networkMode: "PUBLIC" };
+    }
+
     const runtime = new CfnRuntime(this, "Runtime", {
       agentRuntimeName: Names.uniqueResourceName(this, { maxLength: 40 }),
       agentRuntimeArtifact: {
@@ -313,16 +319,68 @@ export class Agent extends Construct {
       networkConfiguration,
       roleArn: role.roleArn,
       protocolConfiguration: "HTTP",
+      // アイドルセッションの保持時間は 900 秒（サービス既定値）を明示的に固定する。
+      //
+      // 【重要】この値を安易に短縮してはならない。過去に 120 秒へ短縮した際、
+      // 処理に 120 秒以上かかる正当な審査項目（MCP ツールを多数呼ぶ項目など）の
+      // microVM が「同期 invocation の処理中にもかかわらず」タイムアウトで強制
+      // 終了され、呼び出し元には RuntimeClientError
+      // （"Runtime initialization time exceeded. Please make sure that
+      // initialization completes in <値>s."）が返り続けてジョブが失敗した。
+      // 公式ドキュメントには「同期呼び出し中はアクティブとして自動追跡される」
+      // 旨の記述があるが、実測ではアイドルタイムアウト値がそのまま処理中の
+      // セッションの kill タイマーとして働く（/ping が Healthy を返し続ける限り
+      // アイドル扱いになるため）。
+      // 審査項目の実行時間上限は invoke-agent Lambda のタイムアウト（15 分 =
+      // 900 秒）なので、900 秒であればタイムアウトより先にセッションが刈られる
+      // ことはない。アイドル尾部のメモリ課金（~$0.06/13 項目ジョブ）は許容する。
+      // 短縮したい場合は、処理中に /ping を HealthyBusy にする対応
+      // （SDK の add_async_task / @app.ping、公式の長時間処理ガイド参照）と
+      // セットで、実環境検証を経てから行うこと。HealthyBusy 化は complete 漏れ・
+      // 暴走ループ時に maxLifetime（既定 8 時間）まで課金が続くリスクを伴う。
+      //
+      // Pin the idle session retention to 900s (the service default),
+      // explicitly.
+      //
+      // IMPORTANT: do not casually lower this value. When it was shortened to
+      // 120s, microVMs of legitimately long-running review items (e.g. items
+      // making many MCP tool calls, taking over 120s) were force-terminated
+      // MID-PROCESSING of a synchronous invocation, surfacing to the caller
+      // as persistent RuntimeClientError ("Runtime initialization time
+      // exceeded. Please make sure that initialization completes in <N>s.")
+      // and failing the job. Although the docs state sync invocations are
+      // automatically tracked as activity, observed behavior is that the
+      // idle timeout acts as a kill timer even while processing (the /ping
+      // keeps reporting plain "Healthy", so the session looks idle).
+      // Item execution is capped by the invoke-agent Lambda timeout (15 min
+      // = 900s), so at 900s the session can never be reaped before the item
+      // itself times out. The idle-tail memory cost (~$0.06 per 13-item job)
+      // is accepted. If shortening is ever needed, pair it with HealthyBusy
+      // ping signaling during processing (SDK add_async_task / @app.ping per
+      // the official long-running-agents guide), validate in a real
+      // environment first, and note that busy signaling risks billing until
+      // maxLifetime (default 8h) if completion is ever missed or a task
+      // loops forever.
+      lifecycleConfiguration: {
+        idleRuntimeSessionTimeout: 900,
+      },
       environmentVariables: {
-        BEDROCK_REGION: bedrockRegion,
         DOCUMENT_BUCKET: documentBucket.bucketName,
         TEMP_BUCKET: tempBucket.bucketName,
-        DOCUMENT_PROCESSING_MODEL_ID: documentProcessingModelId,
-        IMAGE_REVIEW_MODEL_ID: imageReviewModelId,
+        // env キー（DOCUMENT_PROCESSING_MODEL_ID /
+        // IMAGE_REVIEW_MODEL_ID）は review-item-processor（Python）の互換のため
+        // 維持し、双方に統合後の単一 defaultModelId を供給する。
+        DOCUMENT_PROCESSING_MODEL_ID: defaultModelId,
+        IMAGE_REVIEW_MODEL_ID: defaultModelId,
         ENABLE_CITATIONS: enableCitations.toString(),
         ENABLE_CODE_INTERPRETER: enableCodeInterpreter.toString(),
         MEMORY_ID: memory.attrMemoryId,
         AWS_REGION: region,
+        // review-item-processor のログレベルを既定 INFO に
+        // 固定する。logger.py が未設定時 INFO にフォールバックするため必須ではないが、運用で
+        // 一時的に DEBUG へ切り替え可能にするため明示する。文書内容を含みうる debug ログを
+        // 本番で出力させないことが目的。
+        LOG_LEVEL: "INFO",
       },
     });
     this.runtimeArn = runtime.attrAgentRuntimeArn;

--- a/cdk/lib/constructs/ambiguity-detection-processor.ts
+++ b/cdk/lib/constructs/ambiguity-detection-processor.ts
@@ -1,5 +1,4 @@
 import { Construct } from "constructs";
-import * as cdk from "aws-cdk-lib";
 import * as sqs from "aws-cdk-lib/aws-sqs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambdaEventSources from "aws-cdk-lib/aws-lambda-event-sources";
@@ -14,10 +13,20 @@ import { DockerPrismaFunction } from "./docker-prisma-function";
 export interface AmbiguityDetectionProcessorProps {
   vpc: ec2.Vpc;
   databaseConnection: DatabaseConnectionProps;
-  bedrockRegion: string;
-  documentProcessingModelId: string;
   /**
-   * Subnet selection for the worker Lambda. Defaults to PRIVATE_WITH_EGRESS.
+   * 曖昧性検出に使う Bedrock モデル ID（= 全処理共通の既定モデル）。
+   * model-id-consolidation で defaultModelId に統合した。Worker Lambda へは互換のため
+   * env キー `DOCUMENT_PROCESSING_MODEL_ID` として注入する。これを渡さないと
+   * ambiguity-detector.ts のハードコード fallback が使われ、parameter.ts の
+   * defaultModelId を変えても曖昧性検出だけ旧モデルのままになってしまう
+   * （他の処理経路と挙動が食い違う）。
+   */
+  defaultModelId: string;
+  /**
+   * Worker Lambda のサブネット選択。未指定時は PRIVATE_WITH_EGRESS
+   * （従来挙動）。閉域モードでは isolated サブネットが渡される。
+   * Subnet selection for the worker Lambda. Defaults to
+   * PRIVATE_WITH_EGRESS.
    */
   subnetSelection?: ec2.SubnetSelection;
 }
@@ -31,7 +40,7 @@ export class AmbiguityDetectionProcessor extends Construct {
   constructor(
     scope: Construct,
     id: string,
-    props: AmbiguityDetectionProcessorProps,
+    props: AmbiguityDetectionProcessorProps
   ) {
     super(scope, id);
 
@@ -67,7 +76,7 @@ export class AmbiguityDetectionProcessor extends Construct {
           file: "Dockerfile.prisma.lambda",
           platform: Platform.LINUX_ARM64,
           cmd: ["dist/handlers/ambiguity-detection-handler.handler"],
-        },
+        }
       ),
       memorySize: 1024,
       timeout: Duration.minutes(15),
@@ -78,9 +87,11 @@ export class AmbiguityDetectionProcessor extends Construct {
       securityGroups: [this.securityGroup],
       database: props.databaseConnection,
       architecture: lambda.Architecture.ARM_64,
+      // 曖昧性検出も既定モデル（defaultModelId）を使う。
+      // これが無いと ambiguity-detector.ts の fallback（旧モデル）が使われてしまう。
+      // model-id-consolidation: env キーは backend の互換のため維持する。
       environment: {
-        BEDROCK_REGION: props.bedrockRegion,
-        DOCUMENT_PROCESSING_MODEL_ID: props.documentProcessingModelId,
+        DOCUMENT_PROCESSING_MODEL_ID: props.defaultModelId,
       },
     });
 
@@ -88,7 +99,7 @@ export class AmbiguityDetectionProcessor extends Construct {
     this.workerLambda.addEventSource(
       new lambdaEventSources.SqsEventSource(this.queue, {
         batchSize: 1, // Process one message at a time
-      }),
+      })
     );
 
     // Grant Lambda permission to consume messages
@@ -102,7 +113,7 @@ export class AmbiguityDetectionProcessor extends Construct {
           "bedrock:InvokeModelWithResponseStream",
         ],
         resources: ["*"],
-      }),
+      })
     );
   }
 }

--- a/cdk/lib/constructs/checklist-processor.ts
+++ b/cdk/lib/constructs/checklist-processor.ts
@@ -61,16 +61,12 @@ export interface ChecklistProcessorProps {
   logLevel?: sfn.LogLevel;
 
   /**
-   * ドキュメント処理に使用するAIモデルID
-   * @default "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+   * 既定の AI モデル ID（チェックリスト生成に使用）。
+   * defaultModelId に統合した。
+   * Lambda へは互換のため env キー DOCUMENT_PROCESSING_MODEL_ID として注入する。
+   * @default "global.anthropic.claude-sonnet-5"
    */
-  documentProcessingModelId: string;
-
-  /**
-   * Amazon Bedrockを利用するリージョン
-   * @default "us-west-2"
-   */
-  bedrockRegion: string;
+  defaultModelId: string;
 
   /**
    * Subnet selection for the processor Lambda. Defaults to PRIVATE_WITH_EGRESS.
@@ -138,8 +134,9 @@ export class ChecklistProcessor extends Construct {
         },
         environment: {
           DOCUMENT_BUCKET: props.documentBucket.bucketName,
-          BEDROCK_REGION: props.bedrockRegion,
-          DOCUMENT_PROCESSING_MODEL_ID: props.documentProcessingModelId,
+          // env キーは backend の互換のため維持し、
+          // 統合後の単一 defaultModelId を供給する。
+          DOCUMENT_PROCESSING_MODEL_ID: props.defaultModelId,
           CHECKLIST_INLINE_MAP_CONCURRENCY: inlineMapConcurrency.toString(),
         },
         securityGroups: [this.securityGroup],

--- a/cdk/lib/constructs/lambda/invoke-agent/index.ts
+++ b/cdk/lib/constructs/lambda/invoke-agent/index.ts
@@ -27,11 +27,13 @@ const client = new BedrockAgentCoreClient({
  * CloudWatch GenAI Observability, making it difficult to analyze individual items.
  *
  * Solution: Override the X-Ray trace ID with a unique value derived from reviewResultId
- * for each InvokeAgentRuntime call. This creates separate traces per review item
- * while maintaining a single AgentCore session (via shared runtimeSessionId).
+ * for each InvokeAgentRuntime call. Combined with the per-item runtimeSessionId
+ * (see the [SESSION] block in the handler), each review item gets its own
+ * AgentCore session and its own trace.
  *
  * Result: CloudWatch GenAI Observability displays:
- * - 1 session (all items share the same reviewJobId-based session)
+ * - N sessions (one per review item; session IDs share the reviewJobId prefix,
+ *   so all sessions of a job can still be found by prefix search)
  * - N traces (one per review item, each with unique trace ID)
  *
  * X-Ray Trace ID Format: Root=1-{hex-timestamp}-{24-char-hex-id}
@@ -66,7 +68,14 @@ client.middlewareStack.add(
 );
 
 export const handler: Handler = async (event: StepFunctionsInput) => {
-  console.log("Received event:", JSON.stringify(event, null, 2));
+  // イベント全体（toolConfiguration / mcpServers に MCP 秘密を
+  // 含みうる）を JSON ダンプしない。相関に必要な非機微スカラのみを記録する。
+  console.log(
+    `[EVENT] reviewJobId=${event.reviewJobId} checkId=${event.checkId} ` +
+      `reviewResultId=${event.reviewResultId} ` +
+      `documentPaths=${event.preItemResult?.Payload?.documentPaths?.length ?? 0} ` +
+      `hasToolConfiguration=${event.preItemResult?.Payload?.toolConfiguration != null}`,
+  );
 
   try {
     // Transform Step Functions payload to Agent payload format
@@ -84,10 +93,60 @@ export const handler: Handler = async (event: StepFunctionsInput) => {
       modelId: event.preItemResult.Payload.modelId,
     };
 
-    console.log("Transformed payload:", JSON.stringify(agentPayload, null, 2));
+    // payload は toolConfiguration / mcpServers（MCP 秘密）を
+    // 含むため全文をダンプしない。非機微なメタ情報のみ記録する。
+    console.log(
+      `[PAYLOAD] reviewResultId=${agentPayload.reviewResultId} ` +
+        `documentPaths=${agentPayload.documentPaths?.length ?? 0} ` +
+        `modelId=${agentPayload.modelId ?? "default"} ` +
+        `hasToolConfiguration=${agentPayload.toolConfiguration != null}`,
+    );
 
-    // Use same session ID for all review items in the same job
-    const runtimeSessionId = event.reviewJobId.padEnd(33, "0");
+    // セッション ID は「審査項目ごと」に分離する（reviewJobId + reviewResultId）。
+    //
+    // 旧実装は 1 ジョブ = 1 セッション（reviewJobId のみ）を全項目で共有していたが、
+    // AgentCore Runtime は 1 セッション = 1 microVM であり、同一セッションへの
+    // 同時呼び出しは AWS のガイダンス上もアプリ層で直列化すべきものになっている。
+    // 実際、未作成セッションへの同時初回呼び出しは microVM プロビジョニングの
+    // 競合（502）を起こし、さらに当時の bedrock-agentcore SDK 0.1.0 はコンテナ
+    // あたり同時 2 呼び出しまでしか処理しなかったため（1.x で上限は撤廃済み）、
+    // Map ステートの並列度（既定 5）超過分が "Server busy" として拒否され、
+    // InvokeAgentRuntime に RuntimeClientError（"Received error (500) from
+    // runtime"）が返り続けてジョブ全体が失敗していた。SDK の上限撤廃後も、
+    // 1 台の microVM（上限 2vCPU/8GB）に重い文書処理を複数同時に載せる構成は
+    // リソース競合のリスクが残る。
+    // 審査項目は互いに独立で microVM 内に共有状態を持たないため、項目ごとに
+    // セッションを分けることで同一セッションへの同時呼び出しを構造的に排除し、
+    // 上記の故障モードをまとめて解消する。
+    // 同一項目のリトライは同じセッション ID を再利用するため、再試行は
+    // プロビジョニング済みの microVM に到達する。
+    // ID 形式: ULID 26 文字 + "-" + ULID 26 文字 = 53 文字（API 制約は 33〜256 文字・
+    // 英数と -_）。想定外に短い ID が来ても最小長を満たすよう padEnd で保険をかける。
+    //
+    // Use a per-review-item session ID (reviewJobId + reviewResultId).
+    //
+    // The previous implementation shared one session (reviewJobId only) across
+    // all items of a job. An AgentCore session maps to a single microVM, and
+    // AWS guidance says concurrent calls to one session should be serialized
+    // at the application layer. In practice, concurrent first calls to a
+    // not-yet-provisioned session raced the microVM provisioning (502), and
+    // the bedrock-agentcore SDK 0.1.0 used at the time only processed 2
+    // concurrent invocations per container (the cap was removed in 1.x), so
+    // calls beyond the Map state concurrency (default 5) were rejected as
+    // "Server busy", surfacing as persistent RuntimeClientError ("Received
+    // error (500) from runtime") and failing the whole job. Even without the
+    // SDK cap, stacking several heavy document-processing items onto one
+    // microVM (max 2vCPU/8GB) risks resource contention.
+    // Review items are independent and share no in-container state, so giving
+    // each item its own session structurally eliminates concurrent calls to
+    // the same session and all of the failure modes above. Retries of the
+    // same item reuse the same session ID and therefore reach the
+    // already-provisioned microVM.
+    // Format: 26-char ULID + "-" + 26-char ULID = 53 chars (API allows 33-256
+    // chars of alphanumerics, "-", "_"). padEnd guards the 33-char minimum in
+    // case unexpectedly short IDs are ever passed.
+    const runtimeSessionId =
+      `${event.reviewJobId}-${event.reviewResultId}`.padEnd(33, "0");
     console.log(
       `[SESSION] Using runtimeSessionId: ${runtimeSessionId} for reviewJobId: ${event.reviewJobId}, reviewResultId: ${event.reviewResultId}`,
     );
@@ -104,7 +163,13 @@ export const handler: Handler = async (event: StepFunctionsInput) => {
 
     // Read the streaming response
     const responseBody = await streamToString(response.response);
-    console.log("AgentCore response body:", responseBody);
+    // 成功時は本文全文をダンプせず長さのみ記録する。
+    // 非 200（エラー診断が必要）時のみ本文を残す。
+    if (response.statusCode === 200) {
+      console.log(`AgentCore response body length: ${responseBody.length}`);
+    } else {
+      console.log("AgentCore response body (non-200):", responseBody);
+    }
 
     // Check status code and throw error if not 200
     if (response.statusCode !== 200) {

--- a/cdk/lib/constructs/review-processor.ts
+++ b/cdk/lib/constructs/review-processor.ts
@@ -22,22 +22,10 @@ export interface ReviewProcessorProps {
   maxConcurrency?: number; // Add parameter for controlling parallel executions
 
   /**
-   * ドキュメント処理に使用するAIモデルID
-   * @default "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+   * 既定の AI モデル ID。ドキュメント用・画像用の
+   * 2 つを 1 つに統合した（Lambda へは互換のため両 env キーに供給）。
    */
-  documentProcessingModelId: string;
-
-  /**
-   * 画像レビューに使用するAIモデルID
-   * @default "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-   */
-  imageReviewModelId: string;
-
-  /**
-   * Amazon Bedrockを利用するリージョン
-   * @default "us-west-2"
-   */
-  bedrockRegion: string;
+  defaultModelId: string;
 
   /**
    * Citation機能を有効にするかどうか
@@ -124,9 +112,11 @@ export class ReviewProcessor extends Construct {
         environment: {
           DOCUMENT_BUCKET: props.documentBucket.bucketName,
           TEMP_BUCKET: props.tempBucket.bucketName,
-          BEDROCK_REGION: props.bedrockRegion,
-          DOCUMENT_PROCESSING_MODEL_ID: props.documentProcessingModelId,
-          IMAGE_REVIEW_MODEL_ID: props.imageReviewModelId,
+          // env キー（DOCUMENT_PROCESSING_MODEL_ID /
+          // IMAGE_REVIEW_MODEL_ID）は backend/Python の互換のため維持し、双方に
+          // 統合後の単一 defaultModelId を供給する。
+          DOCUMENT_PROCESSING_MODEL_ID: props.defaultModelId,
+          IMAGE_REVIEW_MODEL_ID: props.defaultModelId,
           AVAILABLE_MODELS: JSON.stringify(props.availableModels),
         },
         securityGroups: [this.securityGroup],
@@ -137,11 +127,9 @@ export class ReviewProcessor extends Construct {
 
     // AgentCore Runtime を作成
     this.reviewAgent = new Agent(this, "ReviewAgent", {
-      bedrockRegion: props.bedrockRegion,
       documentBucket: props.documentBucket,
       tempBucket: props.tempBucket,
-      documentProcessingModelId: props.documentProcessingModelId,
-      imageReviewModelId: props.imageReviewModelId,
+      defaultModelId: props.defaultModelId,
       enableCitations: props.enableCitations,
       enableCodeInterpreter: props.enableCodeInterpreter,
       // AgentCore runtime network mode. VPC mode (max isolation) runs the
@@ -187,7 +175,6 @@ export class ReviewProcessor extends Construct {
           : {}),
         environment: {
           AGENT_RUNTIME_ARN: this.reviewAgent.runtimeArn,
-          BEDROCK_REGION: props.bedrockRegion,
         },
         architecture: lambda.Architecture.ARM_64,
         bundling: {

--- a/cdk/lib/parameter-schema.ts
+++ b/cdk/lib/parameter-schema.ts
@@ -46,15 +46,33 @@ const parameterSchema = z.object({
     ),
 
   // AI モデル設定
+  // Single default AI model used across the app (checklist generation and
+  // document review).
+  // アプリ全体（チェックリスト生成・書類審査）で使用する既定 AI モデル。
+  defaultModelId: z
+    .string()
+    .default("global.anthropic.claude-sonnet-5")
+    .describe(
+      "全処理（ドキュメント処理・画像レビュー・チェックリスト生成・曖昧性検出・WebUI 既定）で使う既定 AI モデル ID",
+    ),
+
+  // Deprecated aliases of defaultModelId, accepted for backward compatibility
+  // (normalized in resolveParameters). To be removed in a future release.
+  // defaultModelId の非推奨エイリアス。後方互換のため受け付けます
+  // （resolveParameters で正規化）。将来のリリースで削除予定です。
   documentProcessingModelId: z
     .string()
-    .default("global.anthropic.claude-sonnet-4-6")
-    .describe("ドキュメント処理に使用するAIモデルID"),
+    .optional()
+    .describe(
+      "[非推奨] defaultModelId に統合。後方互換のため受け付ける（旧: ドキュメント処理モデル ID）",
+    ),
 
   imageReviewModelId: z
     .string()
-    .default("global.anthropic.claude-sonnet-4-6")
-    .describe("画像レビューに使用するAIモデルID"),
+    .optional()
+    .describe(
+      "[非推奨] defaultModelId に統合。後方互換のため受け付ける（旧: 画像レビューモデル ID）",
+    ),
 
   // チェックリスト項目ごとに選択可能なモデル一覧
   availableModels: z
@@ -66,6 +84,26 @@ const parameterSchema = z.object({
     )
     .default([
       {
+        modelId: "global.anthropic.claude-sonnet-5",
+        displayName: "Claude Sonnet 5 (Global)",
+      },
+      {
+        modelId: "global.anthropic.claude-opus-4-8",
+        displayName: "Claude Opus 4.8 (Global)",
+      },
+      {
+        modelId: "jp.anthropic.claude-opus-4-8",
+        displayName: "Claude Opus 4.8 (JP)",
+      },
+      {
+        modelId: "global.anthropic.claude-opus-4-7",
+        displayName: "Claude Opus 4.7 (Global)",
+      },
+      {
+        modelId: "jp.anthropic.claude-opus-4-7",
+        displayName: "Claude Opus 4.7 (JP)",
+      },
+      {
         modelId: "global.anthropic.claude-opus-4-6-v1",
         displayName: "Claude Opus 4.6 (Global)",
       },
@@ -74,12 +112,16 @@ const parameterSchema = z.object({
         displayName: "Claude Sonnet 4.6 (Global)",
       },
       {
+        modelId: "jp.anthropic.claude-sonnet-4-6",
+        displayName: "Claude Sonnet 4.6 (JP)",
+      },
+      {
         modelId: "global.anthropic.claude-haiku-4-5-20251001-v1:0",
         displayName: "Claude Haiku 4.5 (Global)",
       },
       {
-        modelId: "global.anthropic.claude-sonnet-4-20250514-v1:0",
-        displayName: "Claude Sonnet 4 (Global)",
+        modelId: "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+        displayName: "Claude Haiku 4.5 (JP)",
       },
     ])
     .describe(
@@ -173,7 +215,23 @@ const parameterSchema = z.object({
     .describe(
       "Feedback Aggregatorの実行スケジュール（EventBridge schedule expression）",
     ),
-});
+})
+  // PR02-3: defaultModelId は availableModels から選択可能でなければならない。
+  // 不一致のまま通すと、WebUI（先頭へ無言 fallback）・/models handler（素通し）・
+  // ワーカー（固定定数へ独自 fallback）の 3 系統で解決が分岐する。synth 時に
+  // fail-fast する（availableModels を空にしてモデル選択 UI を隠す構成は対象外）。
+  .superRefine((p, ctx) => {
+    if (
+      p.availableModels.length > 0 &&
+      !p.availableModels.some((m) => m.modelId === p.defaultModelId)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["defaultModelId"],
+        message: `defaultModelId '${p.defaultModelId}' is not in availableModels — add it to availableModels or pick one of: ${p.availableModels.map((m) => m.modelId).join(", ")}`,
+      });
+    }
+  });
 
 // パラメータの型定義（型安全性のため）
 export type Parameters = z.infer<typeof parameterSchema>;
@@ -187,10 +245,29 @@ export function resolveParameters(
 ): Parameters {
   try {
     // パラメータをマージ
-    const mergedParams = {
+    // Merge as Record<string, any> so deprecated alias keys are also allowed.
+    // 非推奨エイリアスのキーも扱えるよう Record<string, any> としてマージします。
+    const mergedParams: Record<string, any> = {
       ...userParameters, // parameter.tsからの値
       ...contextParams, // コンテキストパラメータ（コマンドラインから渡された値）
     };
+
+    // Backward compatibility: when defaultModelId is not set, inherit the
+    // value from the deprecated names (documentProcessingModelId first).
+    // 後方互換: defaultModelId が未設定の場合、非推奨の旧パラメータ名から
+    // 値を引き継ぎます（documentProcessingModelId を優先）。
+    if (
+      mergedParams.defaultModelId === undefined ||
+      mergedParams.defaultModelId === null ||
+      mergedParams.defaultModelId === ""
+    ) {
+      const legacy =
+        mergedParams.documentProcessingModelId ??
+        mergedParams.imageReviewModelId;
+      if (typeof legacy === "string" && legacy.length > 0) {
+        mergedParams.defaultModelId = legacy;
+      }
+    }
 
     // バリデーションを実行（デフォルト値は自動的に適用される）
     const validatedParams = parameterSchema.parse(mergedParams);

--- a/cdk/lib/parameter.ts
+++ b/cdk/lib/parameter.ts
@@ -27,47 +27,51 @@ export const parameters = {
   // bedrockRegion: "us-east-1", // Bedrockを利用するリージョン（デフォルト：us-west-2）
   // AI モデル設定
   // デフォルトモデル以外を使用したい場合に設定します
-  // 注意: モデルIDのプレフィックス（us., eu., apac.など）はbedrockRegionに対応している必要があります
+  // model-id-consolidation: documentProcessingModelId / imageReviewModelId は
+  // 単一の defaultModelId に統合されました（旧 2 名は後方互換のため引き続き受け付けます）
+  // アプリ全体（チェックリスト生成・書類審査）で使用する既定モデルです。
+  // チェックリスト項目ごとにモデルを選択した場合（availableModels）は、そちらが優先されます。
+  // 注意: モデルIDのプレフィックス（global., jp., us. など）はデプロイ先リージョンで
+  // 利用可能な推論プロファイルを選んでください
   // 詳細: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
   // ---------------------------------------------------
-  // documentProcessingModelId: "global.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (Global)
-  // documentProcessingModelId: "us.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (US)
-  // documentProcessingModelId: "eu.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (EU)
-  // documentProcessingModelId: "jp.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (JP)
-  // documentProcessingModelId: "global.anthropic.claude-sonnet-4-5-20250929-v1:0", // Claude 4.5 Sonnet (Global)
-  // documentProcessingModelId: "us.anthropic.claude-sonnet-4-5-20250929-v1:0", // Claude 4.5 Sonnet (US)
-  // documentProcessingModelId: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", // Claude 4.5 Sonnet (EU)
-  // documentProcessingModelId: "jp.anthropic.claude-sonnet-4-5-20250929-v1:0", // Claude 4.5 Sonnet (JP)
-  // documentProcessingModelId: "global.anthropic.claude-opus-4-5-20251101-v1:0", // Claude 4.5 Opus (Global)
-  // documentProcessingModelId: "global.anthropic.claude-opus-4-6-v1", // Claude Opus 4.6 (Global)
-  // documentProcessingModelId: "global.anthropic.claude-sonnet-4-20250514-v1:0", // Claude 4 Sonnet (Global)
-  // documentProcessingModelId: "global.anthropic.claude-sonnet-4-20250514-v1:0", // Claude 4 Sonnet (Global)
-  // documentProcessingModelId: "eu.anthropic.claude-sonnet-4-20250514-v1:0", // Claude 4 Sonnet (EU)
-  // documentProcessingModelId: "apac.anthropic.claude-sonnet-4-20250514-v1:0", // Claude 4 Sonnet (APAC)
-  // documentProcessingModelId: "apac.anthropic.claude-3-7-sonnet-20250219-v1:0",  // 日本リージョンでClaude利用する場合
-  // documentProcessingModelId: "mistral.mistral-large-2407-v1:0", // Mistral利用する場合
-  // documentProcessingModelId: "us.amazon.nova-2-omni-v1:0", // Nova 2 Omni
-  // imageReviewModelId: "global.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (Global)
-  // imageReviewModelId: "us.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (US)
-  // imageReviewModelId: "eu.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (EU)
-  // imageReviewModelId: "jp.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (JP)
-  // imageReviewModelId: "global.anthropic.claude-sonnet-4-5-20250929-v1:0", // Claude 4.5 Sonnet (Global)
-  // imageReviewModelId: "us.anthropic.claude-sonnet-4-5-20250929-v1:0", // Claude 4.5 Sonnet (US)
-  // imageReviewModelId: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", // Claude 4.5 Sonnet (EU)
-  // imageReviewModelId: "jp.anthropic.claude-sonnet-4-5-20250929-v1:0", // Claude 4.5 Sonnet (JP)
-  // imageReviewModelId: "global.anthropic.claude-opus-4-5-20251101-v1:0", // Claude 4.5 Opus (Global)
-  // imageReviewModelId: "global.anthropic.claude-opus-4-6-v1", // Claude Opus 4.6 (Global)
-  // imageReviewModelId: "global.anthropic.claude-sonnet-4-20250514-v1:0", // Claude 4 Sonnet (Global)
-  // imageReviewModelId: "eu.anthropic.claude-sonnet-4-20250514-v1:0", // Claude 4 Sonnet (EU)
-  // imageReviewModelId: "apac.anthropic.claude-sonnet-4-20250514-v1:0", // Claude 4 Sonnet (APAC)
-  // imageReviewModelId: "apac.amazon.nova-premier-v1:0", // 画像レビュー用モデル（例：Nova Premier）
-  // imageReviewModelId: "us.amazon.nova-2-omni-v1:0", // Nova 2 Omni
+  // defaultModelId: "global.anthropic.claude-sonnet-5", // Claude Sonnet 5 (Global) — default: "global.anthropic.claude-sonnet-5"
+  // defaultModelId: "global.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (Global)
+  // defaultModelId: "jp.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (JP)
+  // defaultModelId: "global.anthropic.claude-opus-4-8", // Claude Opus 4.8 (Global)
+  // defaultModelId: "jp.anthropic.claude-opus-4-8", // Claude Opus 4.8 (JP)
+  // defaultModelId: "global.anthropic.claude-opus-4-7", // Claude Opus 4.7 (Global)
+  // defaultModelId: "jp.anthropic.claude-opus-4-7", // Claude Opus 4.7 (JP)
+  // defaultModelId: "global.anthropic.claude-opus-4-6-v1", // Claude Opus 4.6 (Global)
+  // defaultModelId: "global.anthropic.claude-haiku-4-5-20251001-v1:0", // Claude Haiku 4.5 (Global)
+  // defaultModelId: "jp.anthropic.claude-haiku-4-5-20251001-v1:0", // Claude Haiku 4.5 (JP)
   // チェックリスト項目ごとに選択可能なモデル一覧
-  // デフォルトでは Opus 4.6, Sonnet 4.6, Haiku 4.5 が設定されています
+  // 以下のコメントアウトされた一覧はスキーマのデフォルトと同一です
   // カスタマイズする場合はコメントを外して編集してください
   // 空配列に設定するとモデル選択UIが非表示になります
+  // モデルを追加する場合は review-item-processor/model_config.py への価格登録も必要です
   // ---------------------------------------------------
   // availableModels: [
+  //   {
+  //     modelId: "global.anthropic.claude-sonnet-5",
+  //     displayName: "Claude Sonnet 5 (Global)",
+  //   },
+  //   {
+  //     modelId: "global.anthropic.claude-opus-4-8",
+  //     displayName: "Claude Opus 4.8 (Global)",
+  //   },
+  //   {
+  //     modelId: "jp.anthropic.claude-opus-4-8",
+  //     displayName: "Claude Opus 4.8 (JP)",
+  //   },
+  //   {
+  //     modelId: "global.anthropic.claude-opus-4-7",
+  //     displayName: "Claude Opus 4.7 (Global)",
+  //   },
+  //   {
+  //     modelId: "jp.anthropic.claude-opus-4-7",
+  //     displayName: "Claude Opus 4.7 (JP)",
+  //   },
   //   {
   //     modelId: "global.anthropic.claude-opus-4-6-v1",
   //     displayName: "Claude Opus 4.6 (Global)",
@@ -77,12 +81,16 @@ export const parameters = {
   //     displayName: "Claude Sonnet 4.6 (Global)",
   //   },
   //   {
+  //     modelId: "jp.anthropic.claude-sonnet-4-6",
+  //     displayName: "Claude Sonnet 4.6 (JP)",
+  //   },
+  //   {
   //     modelId: "global.anthropic.claude-haiku-4-5-20251001-v1:0",
   //     displayName: "Claude Haiku 4.5 (Global)",
   //   },
   //   {
-  //     modelId: "global.anthropic.claude-sonnet-4-20250514-v1:0",
-  //     displayName: "Claude Sonnet 4 (Global)",
+  //     modelId: "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+  //     displayName: "Claude Haiku 4.5 (JP)",
   //   },
   // ],
   // // モデル選択UIを無効にする場合:

--- a/cdk/lib/rapid-stack.ts
+++ b/cdk/lib/rapid-stack.ts
@@ -55,20 +55,27 @@ export class RapidStack extends cdk.Stack {
       ? { subnetType: ec2.SubnetType.PRIVATE_ISOLATED }
       : { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS };
 
-    // Closed mode: warn (don't block) on cross-region global.* profiles that
-    // may route data outside bedrockRegion; recommend region-pinned IDs.
+    // 閉域モードで "global." プレフィックスのクロスリージョン推論プロファイル
+    // が指定されている場合は警告する。推論リクエストがデプロイリージョン外へ
+    // ルーティングされ得るため、厳密なデータレジデンシー要件がある場合は
+    // リージョン固定のプロファイル（例: "jp."）への変更を促す。切替判断は
+    // 利用者に委ねるため、エラーにはせず合成は継続する。
+    // Warn (not fail) when closed-network mode uses "global." cross-region
+    // inference profiles, which may route inference outside the region.
     if (closedNetwork) {
-      const configuredModelIds = [
-        props.parameters.documentProcessingModelId,
-        props.parameters.imageReviewModelId,
-        ...props.parameters.availableModels.map((m) => m.modelId),
-      ];
-      const wideGeoIds = configuredModelIds.filter((id) =>
-        id.startsWith("global."),
+      const globalModelIds = Array.from(
+        new Set(
+          [
+            props.parameters.defaultModelId,
+            ...props.parameters.availableModels.map((m) => m.modelId),
+          ].filter((modelId) => modelId.startsWith("global.")),
+        ),
       );
-      if (wideGeoIds.length > 0) {
+      if (globalModelIds.length > 0) {
         cdk.Annotations.of(this).addWarning(
-          `closedNetwork: the following model IDs use cross-region (global.*) inference profiles that may route data outside bedrockRegion (${props.parameters.bedrockRegion}): ${[...new Set(wideGeoIds)].join(", ")}. For true data residency, use region-pinned IDs (e.g. us.* for us-west-2).`,
+          `closedNetwork: the following model IDs use the "global." cross-region inference profile and may route inference outside the deployment region: ${globalModelIds.join(
+            ", ",
+          )}. For strict data residency, switch to region-pinned profiles (e.g. "jp.").`,
         );
       }
     }
@@ -188,8 +195,7 @@ export class RapidStack extends cdk.Stack {
           props.parameters.checklistInlineMapConcurrency || 1,
         logLevel: sfn.LogLevel.ALL,
         databaseConnection: database.connection,
-        documentProcessingModelId: props.parameters.documentProcessingModelId,
-        bedrockRegion: props.parameters.bedrockRegion,
+        defaultModelId: props.parameters.defaultModelId,
         subnetSelection: lambdaSubnetSelection,
       },
     );
@@ -202,9 +208,7 @@ export class RapidStack extends cdk.Stack {
       logLevel: sfn.LogLevel.ALL,
       maxConcurrency: props.parameters.reviewMapConcurrency || 1,
       databaseConnection: database.connection,
-      documentProcessingModelId: props.parameters.documentProcessingModelId,
-      imageReviewModelId: props.parameters.imageReviewModelId,
-      bedrockRegion: props.parameters.bedrockRegion,
+      defaultModelId: props.parameters.defaultModelId,
       enableCitations: props.parameters.enableCitations,
       enableCodeInterpreter: props.parameters.enableCodeInterpreter,
       availableModels: props.parameters.availableModels,
@@ -248,8 +252,7 @@ export class RapidStack extends cdk.Stack {
       {
         vpc,
         databaseConnection: database.connection,
-        bedrockRegion: props.parameters.bedrockRegion,
-        documentProcessingModelId: props.parameters.documentProcessingModelId,
+        defaultModelId: props.parameters.defaultModelId,
         subnetSelection: lambdaSubnetSelection,
       },
     );
@@ -293,7 +296,7 @@ export class RapidStack extends cdk.Stack {
         REVIEW_QUEUE_URL: reviewQueueProcessor.queue.queueUrl,
         REVIEW_QUEUE_MAX_DEPTH: props.parameters.reviewQueueMaxDepth.toString(),
         AVAILABLE_MODELS: JSON.stringify(props.parameters.availableModels),
-        DEFAULT_MODEL_ID: props.parameters.documentProcessingModelId,
+        DEFAULT_MODEL_ID: props.parameters.defaultModelId,
       },
       auth: auth, // Authインスタンスを渡す
     });
@@ -425,16 +428,20 @@ export class RapidStack extends cdk.Stack {
       value: s3TempStorage.bucket.bucketName,
     });
 
-    new cdk.CfnOutput(this, "BedrockRegion", {
-      value: props.parameters.bedrockRegion,
+    // model-id-consolidation: 既定モデル ID の CfnOutput。
+    new cdk.CfnOutput(this, "DefaultModelId", {
+      value: props.parameters.defaultModelId,
     });
 
+    // 後方互換（deprecated）: 旧出力名を参照する外部ツール（例: review-item-processor/
+    // test_mcp.py が outputs["DocumentProcessingModelId"] を読む）を壊さないため、
+    // 統合後の単一値を同じ名前でエコーする。将来のリリースで削除予定。
     new cdk.CfnOutput(this, "DocumentProcessingModelId", {
-      value: props.parameters.documentProcessingModelId,
+      value: props.parameters.defaultModelId,
     });
 
     new cdk.CfnOutput(this, "ImageReviewModelId", {
-      value: props.parameters.imageReviewModelId,
+      value: props.parameters.defaultModelId,
     });
 
     // Fix migrationLambda.functionArn

--- a/cdk/test/available-models-additive.test.ts
+++ b/cdk/test/available-models-additive.test.ts
@@ -1,0 +1,220 @@
+import { parameters as rawParameters } from "../lib/parameter";
+import { resolveParameters } from "../lib/parameter-schema";
+
+/**
+ * availableModels / デフォルトモデルの整合と additive 性
+ *
+ * 「`availableModels` を変更しても、変更前に含まれていた各モデルの modelId・
+ *  displayName・相対順序が保持され（additive）、schema default が期待リストと
+ *  一致する」ことを検証する。
+ *
+ * 2026-07-01 に Claude Sonnet 5 (Global) を先頭（＝既定モデル）に追加し、
+ * デフォルトモデルを Sonnet 5 Global へ変更した。model-id-consolidation で
+ * documentProcessingModelId / imageReviewModelId を単一の defaultModelId に統合した
+ * （旧 2 名は deprecated alias として後方互換で受け付ける）。
+ *
+ * さらに parameter.ts は「全行コメントアウト・デフォルトから変更する場合のみ
+ * コメントを外す」運用に変更した。これによりデフォルト値の単一情報源は
+ * parameter-schema.ts となる。本テストは現行の期待リスト `EXPECTED_MODELS` を
+ * 固定し、次を検証する:
+ *   1. parameter-schema.ts の zod default が EXPECTED_MODELS と完全一致
+ *   2. 実効値 resolveParameters({}).availableModels が EXPECTED_MODELS と完全一致
+ *   3. 先頭（既定表示に使われる）が Claude Sonnet 5 (Global) である
+ *   4. デフォルトモデル ID が availableModels に含まれる（UI で選択肢として解決できる）
+ *   5. modelId に重複が無い
+ *   6. リポジトリ出荷状態の parameter.ts がモデル設定を上書きしていない
+ *      （schema default がそのまま実効値になる）
+ *
+ * fast-check は CDK の依存に含まれないため、Property を例ベース／パラメトライズド
+ * （test.each）テストとして表現する。
+ */
+
+interface ModelEntry {
+  modelId: string;
+  displayName: string;
+}
+
+/** 既定モデル（defaultModelId）の期待値。 */
+const EXPECTED_DEFAULT_MODEL_ID = "global.anthropic.claude-sonnet-5";
+
+/**
+ * parameter-schema.ts の availableModels デフォルト（順序・modelId・
+ * displayName まで含めた完全な期待リスト）。
+ */
+const EXPECTED_MODELS: ReadonlyArray<ModelEntry> = [
+  {
+    modelId: "global.anthropic.claude-sonnet-5",
+    displayName: "Claude Sonnet 5 (Global)",
+  },
+  {
+    modelId: "global.anthropic.claude-opus-4-8",
+    displayName: "Claude Opus 4.8 (Global)",
+  },
+  {
+    modelId: "jp.anthropic.claude-opus-4-8",
+    displayName: "Claude Opus 4.8 (JP)",
+  },
+  {
+    modelId: "global.anthropic.claude-opus-4-7",
+    displayName: "Claude Opus 4.7 (Global)",
+  },
+  {
+    modelId: "jp.anthropic.claude-opus-4-7",
+    displayName: "Claude Opus 4.7 (JP)",
+  },
+  {
+    modelId: "global.anthropic.claude-opus-4-6-v1",
+    displayName: "Claude Opus 4.6 (Global)",
+  },
+  {
+    modelId: "global.anthropic.claude-sonnet-4-6",
+    displayName: "Claude Sonnet 4.6 (Global)",
+  },
+  {
+    modelId: "jp.anthropic.claude-sonnet-4-6",
+    displayName: "Claude Sonnet 4.6 (JP)",
+  },
+  {
+    modelId: "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+    displayName: "Claude Haiku 4.5 (Global)",
+  },
+  {
+    modelId: "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+    displayName: "Claude Haiku 4.5 (JP)",
+  },
+];
+
+/** 先頭（＝既定モデルの表示に使われる）が Sonnet 5 (Global) であることを検証。 */
+const EXPECTED_HEAD: ModelEntry = EXPECTED_MODELS[0];
+
+/**
+ * availableModels の普遍的性質を検証する:
+ * (a) 期待リストと順序・modelId・displayName まで完全一致
+ * (b) 先頭が Claude Sonnet 5 (Global)
+ * (c) modelId に重複が無い
+ * (d) 既定モデル ID が availableModels に含まれる（選択肢として解決可能）
+ */
+function assertModelList(actual: ModelEntry[]): void {
+  // (a) 完全一致
+  expect(actual).toEqual(EXPECTED_MODELS);
+
+  // (b) 先頭が Sonnet 5 (Global)
+  expect(actual[0]).toEqual(EXPECTED_HEAD);
+
+  // (c) modelId に重複が無い
+  const ids = actual.map((m) => m.modelId);
+  expect(new Set(ids).size).toBe(ids.length);
+
+  // (d) 既定モデル ID が選択肢に含まれる
+  expect(ids).toContain(EXPECTED_DEFAULT_MODEL_ID);
+}
+
+describe("availableModels / default model consistency", () => {
+  describe("リポジトリ出荷状態の parameter.ts（全行コメントアウト運用）", () => {
+    test("モデル関連の設定を上書きしない（schema default がそのまま実効値になる）", () => {
+      expect(rawParameters).not.toHaveProperty("availableModels");
+      expect(rawParameters).not.toHaveProperty("defaultModelId");
+    });
+  });
+
+  describe("parameter-schema.ts の availableModels デフォルト配列", () => {
+    // availableModels を undefined にすると zod がスキーマ default を適用する。
+    const actual = resolveParameters({ availableModels: undefined })
+      .availableModels as ModelEntry[];
+
+    test("非空の配列として取得できる", () => {
+      expect(Array.isArray(actual)).toBe(true);
+      expect(actual.length).toBeGreaterThan(0);
+    });
+
+    test("現行の期待リスト（Sonnet 5 先頭）と完全一致し、重複・欠落が無い", () => {
+      assertModelList(actual);
+    });
+
+    test.each(EXPECTED_MODELS)(
+      "モデル %s は modelId・displayName を改変なく保持する",
+      (expected) => {
+        const match = actual.find((m) => m.modelId === expected.modelId);
+        expect(match).toBeDefined();
+        expect(match!.displayName).toBe(expected.displayName);
+      },
+    );
+  });
+
+  describe("実効値 resolveParameters({}).availableModels（AVAILABLE_MODELS 供給値）", () => {
+    // parameter.ts は上書きしないため、実効値は schema default と一致する。
+    const actual = resolveParameters({}).availableModels as ModelEntry[];
+
+    test("非空の配列として取得できる", () => {
+      expect(Array.isArray(actual)).toBe(true);
+      expect(actual.length).toBeGreaterThan(0);
+    });
+
+    test("現行の期待リスト（Sonnet 5 先頭）と完全一致し、重複・欠落が無い", () => {
+      assertModelList(actual);
+    });
+
+    test("schema default と実効値が一致する（解決で改変されない）", () => {
+      const schemaDefault = resolveParameters({ availableModels: undefined })
+        .availableModels as ModelEntry[];
+      expect(actual).toEqual(schemaDefault);
+    });
+  });
+
+  describe("既定モデル（defaultModelId）", () => {
+    const resolved = resolveParameters({});
+
+    test("実効値の既定モデルが Sonnet 5 (Global) である", () => {
+      expect(resolved.defaultModelId).toBe(EXPECTED_DEFAULT_MODEL_ID);
+    });
+
+    test("schema default の既定モデルも Sonnet 5 (Global) である", () => {
+      const schemaResolved = resolveParameters({
+        defaultModelId: undefined,
+        documentProcessingModelId: undefined,
+        imageReviewModelId: undefined,
+      });
+      expect(schemaResolved.defaultModelId).toBe(EXPECTED_DEFAULT_MODEL_ID);
+    });
+
+    test("既定モデル ID が availableModels の選択肢に含まれる", () => {
+      const ids = (resolved.availableModels as ModelEntry[]).map(
+        (m) => m.modelId,
+      );
+      expect(ids).toContain(resolved.defaultModelId);
+    });
+  });
+
+  // model-id-consolidation: 旧パラメータ名（documentProcessingModelId /
+  // imageReviewModelId）は defaultModelId に統合したが、既存デプロイヤーが旧名で
+  // 設定した値を無視しないよう deprecated alias として受け付ける。優先順位は
+  // defaultModelId > documentProcessingModelId > imageReviewModelId。
+  describe("後方互換: 旧パラメータ名の deprecated alias", () => {
+    test("defaultModelId 未設定なら documentProcessingModelId を引き継ぐ", () => {
+      const resolved = resolveParameters({
+        defaultModelId: undefined,
+        documentProcessingModelId: "global.anthropic.claude-opus-4-8",
+        imageReviewModelId: undefined,
+      });
+      expect(resolved.defaultModelId).toBe("global.anthropic.claude-opus-4-8");
+    });
+
+    test("documentProcessingModelId も未設定なら imageReviewModelId を引き継ぐ", () => {
+      const resolved = resolveParameters({
+        defaultModelId: undefined,
+        documentProcessingModelId: undefined,
+        imageReviewModelId: "jp.anthropic.claude-opus-4-7",
+      });
+      expect(resolved.defaultModelId).toBe("jp.anthropic.claude-opus-4-7");
+    });
+
+    test("defaultModelId が明示されていれば旧名より優先される", () => {
+      const resolved = resolveParameters({
+        defaultModelId: "global.anthropic.claude-sonnet-4-6",
+        documentProcessingModelId: "global.anthropic.claude-opus-4-8",
+        imageReviewModelId: "jp.anthropic.claude-opus-4-7",
+      });
+      expect(resolved.defaultModelId).toBe("global.anthropic.claude-sonnet-4-6");
+    });
+  });
+});

--- a/cdk/test/parameter-handling.test.ts
+++ b/cdk/test/parameter-handling.test.ts
@@ -74,3 +74,23 @@ describe("Parameter Handling Tests", () => {
     });
   });
 });
+
+// PR02-3: defaultModelId ∈ availableModels の synth 時 fail-fast。
+describe("defaultModelId must be selectable from availableModels (PR02-3)", () => {
+  test("rejects a defaultModelId that is not in availableModels", () => {
+    expect(() =>
+      resolveParameters({
+        defaultModelId: "not.in.the.list",
+        availableModels: [{ modelId: "a.model", displayName: "A" }],
+      })
+    ).toThrow(/not in availableModels/);
+  });
+
+  test("accepts when availableModels is empty (model selector hidden)", () => {
+    const parameters = resolveParameters({
+      defaultModelId: "any.model",
+      availableModels: [],
+    });
+    expect(parameters.defaultModelId).toBe("any.model");
+  });
+});

--- a/deploy.yml
+++ b/deploy.yml
@@ -73,15 +73,10 @@ Parameters:
     Default: "us-west-2"
     Description: Amazon Bedrockを利用するリージョン
 
-  DocumentProcessingModelId:
+  DefaultModelId:
     Type: String
     Default: ""
-    Description: ドキュメント処理に使用するAIモデルID
-
-  ImageReviewModelId:
-    Type: String
-    Default: ""
-    Description: 画像レビューに使用するAIモデルID
+    Description: すべての処理で使う既定AIモデルID（defaultModelId に対応。旧 DocumentProcessingModelId/ImageReviewModelId は統合済み）
 
   RepoUrl:
     Type: String
@@ -214,10 +209,8 @@ Resources:
             Value: !Ref AgentCoreNetworkMode
           - Name: BEDROCK_REGION
             Value: !Ref BedrockRegion
-          - Name: DOCUMENT_PROCESSING_MODEL_ID
-            Value: !Ref DocumentProcessingModelId
-          - Name: IMAGE_REVIEW_MODEL_ID
-            Value: !Ref ImageReviewModelId
+          - Name: DEFAULT_MODEL_ID
+            Value: !Ref DefaultModelId
           - Name: REPO_URL
             Value: !Ref RepoUrl
           - Name: BRANCH
@@ -271,8 +264,7 @@ Resources:
                   "echo '' >> cdk/lib/parameter.ts",
                   "echo '  // Bedrock設定' >> cdk/lib/parameter.ts",
                   "echo '  bedrockRegion: \"'$BEDROCK_REGION'\",' >> cdk/lib/parameter.ts",
-                  "if [ ! -z \"$DOCUMENT_PROCESSING_MODEL_ID\" ]; then echo '  documentProcessingModelId: \"'$DOCUMENT_PROCESSING_MODEL_ID'\",' >> cdk/lib/parameter.ts; fi",
-                  "if [ ! -z \"$IMAGE_REVIEW_MODEL_ID\" ]; then echo '  imageReviewModelId: \"'$IMAGE_REVIEW_MODEL_ID'\",' >> cdk/lib/parameter.ts; fi",
+                  "if [ ! -z \"$DEFAULT_MODEL_ID\" ]; then echo '  defaultModelId: \"'$DEFAULT_MODEL_ID'\",' >> cdk/lib/parameter.ts; fi",
                   "echo '' >> cdk/lib/parameter.ts",
                   "echo '  // MCP設定' >> cdk/lib/parameter.ts",
                   "if [ \"$MCP_ADMIN\" = \"true\" ]; then echo '  mcpAdmin: true,' >> cdk/lib/parameter.ts; else echo '  mcpAdmin: false,' >> cdk/lib/parameter.ts; fi",

--- a/docs/en/deployment-options.md
+++ b/docs/en/deployment-options.md
@@ -33,12 +33,14 @@ Most options map directly to the CDK parameters described in [Parameter Customiz
 | `--closed-network`               | Deploy in fully closed network mode (true/false, default: false). Maps to `closedNetwork`; see [Closed / Private Network Deployment](#closed--private-network-deployment). |
 | `--agentcore-network-mode`       | AgentCore Runtime network mode when closed, `PUBLIC` or `VPC` (default: PUBLIC). Maps to `agentCoreNetworkMode`.    |
 | `--bedrock-region`               | Region to use for Amazon Bedrock (default: us-west-2). Maps to `bedrockRegion`.                                     |
-| `--document-model`               | AI model ID for document processing (default: global.anthropic.claude-sonnet-4-6). Maps to `documentProcessingModelId`. |
-| `--image-model`                  | AI model ID for image review processing (default: global.anthropic.claude-sonnet-4-6). Maps to `imageReviewModelId`. |
+| `--default-model`                | AI model ID to use as the default for all processing. Maps to `defaultModelId`. Example: `--default-model global.anthropic.claude-sonnet-5` |
 | `--disable-ipv6`                 | Disable IPv6 support in the frontend WAF and CloudFront.                                                            |
 | `--repo-url`                     | URL of the repository to deploy.                                                                                    |
 | `--branch`                       | Branch name to deploy.                                                                                              |
 | `--tag`                          | Deploy a specific Git tag.                                                                                          |
+
+> [!Note]
+> The former `--document-model` and `--image-model` options are deprecated and will be removed in a future release. They are still accepted for backward compatibility, but both now map to the single `defaultModelId` parameter. Use `--default-model` instead.
 
 ## Closed / Private Network Deployment
 
@@ -82,55 +84,45 @@ Please review the following characteristics and constraints before enabling clos
 
 This application uses Strands agents with tools such as file reading, so you must select **models that support tool use**.
 
-**Examples of tool-use supported models**:
+**Examples of tool-use supported models** (the models included in `availableModels` by default):
 
-- `global.anthropic.claude-opus-4-6-v1` (Claude Opus 4.6 Global)
-- `global.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6 Global)
-- `us.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6 US)
-- `eu.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6 EU)
-- `jp.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6 JP)
-- `global.anthropic.claude-haiku-4-5-20251001-v1:0` (Claude Haiku 4.5 Global)
-- `global.anthropic.claude-opus-4-5-20251101-v1:0` (Claude Opus 4.5 Global)
-- `global.anthropic.claude-sonnet-4-5-20250929-v1:0` (Claude Sonnet 4.5 Global)
-- `us.anthropic.claude-sonnet-4-5-20250929-v1:0` (Claude Sonnet 4.5 US)
-- `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` (Claude Sonnet 4.5 EU)
-- `jp.anthropic.claude-sonnet-4-5-20250929-v1:0` (Claude Sonnet 4.5 JP)
-- `global.anthropic.claude-sonnet-4-20250514-v1:0` (Claude Sonnet 4 Global)
-- `us.anthropic.claude-sonnet-4-20250514-v1:0` (Claude Sonnet 4 US)
-- `eu.anthropic.claude-sonnet-4-20250514-v1:0` (Claude Sonnet 4 EU)
-- `apac.anthropic.claude-sonnet-4-20250514-v1:0` (Claude Sonnet 4 APAC)
-- `mistral.mistral-large-2407-v1:0` (Mistral Large 2)
-- `us.amazon.nova-premier-v1:0` (Amazon Nova Premier)
-- `us.amazon.nova-2-omni-v1:0` (Amazon Nova 2 Omni)
+- `global.anthropic.claude-sonnet-5` (Claude Sonnet 5, Global) — default
+- `global.anthropic.claude-opus-4-8` (Claude Opus 4.8, Global)
+- `jp.anthropic.claude-opus-4-8` (Claude Opus 4.8, JP)
+- `global.anthropic.claude-opus-4-7` (Claude Opus 4.7, Global)
+- `jp.anthropic.claude-opus-4-7` (Claude Opus 4.7, JP)
+- `global.anthropic.claude-opus-4-6-v1` (Claude Opus 4.6, Global)
+- `global.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6, Global)
+- `jp.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6, JP)
+- `global.anthropic.claude-haiku-4-5-20251001-v1:0` (Claude Haiku 4.5, Global)
+- `jp.anthropic.claude-haiku-4-5-20251001-v1:0` (Claude Haiku 4.5, JP)
 
 **Important notes**:
 
-- **Cross-region inference profiles**: When using cross-region inference, regional prefixes like `us.`, `eu.`, `apac.` are required for model IDs
-- **Official documentation**: [Supported models and model features - Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html)
+- **Cross-region inference profiles**: When using cross-region inference, a regional prefix (`global.`, `us.`, `eu.`, `apac.`, `jp.`) is required in the model ID, and the prefix must be consistent with the region where the stack (Amazon Bedrock) is deployed. For example, a `jp.*` model selected on a **us-east-1** deployment fails with `ValidationException: The provided model identifier is invalid.`. Note that the `availableModels` list bundled with this sample only ships `global.` / `jp.` profiles; add other prefixes (`us.` / `eu.` / `apac.`) yourself if your deployment region needs them.
+- **Official documentation**: [Supported models and model features - Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html) / [Amazon Bedrock model cards](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html)
 
-**Configuration example**: edit the `cdk/lib/parameter.ts` file directly.
+**Configuration example (running inference in Japan)**: edit `cdk/lib/parameter.ts` as follows. Amazon Bedrock uses the region where the stack is deployed, so to use the `jp.` inference profiles, deploy the stack in a Japanese region (Tokyo, `ap-northeast-1`), for example by setting `CDK_DEFAULT_REGION=ap-northeast-1` before deployment.
 
 ```typescript
 export const parameters = {
-  documentProcessingModelId: "global.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (Global)
-  bedrockRegion: "us-west-2", // Oregon region
+  defaultModelId: "jp.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (JP)
   // ...
 };
 ```
 
 ### Per-Checklist-Item Model Selection
 
-By default, each checklist item can be assigned a specific AI model from the `availableModels` list. The default set includes Claude Opus 4.6, Sonnet 4.6, Haiku 4.5, and Sonnet 4 (Global). When no model is selected for an item, `documentProcessingModelId` (default: `global.anthropic.claude-sonnet-4-6`) is used for documents, and `imageReviewModelId` (default: `global.anthropic.claude-sonnet-4-6`) is used for images.
+By default, each checklist item can be assigned a specific AI model from the `availableModels` list. When no model is selected for an item, the review falls back to `defaultModelId` (the same default is used for documents and images alike — the model is multimodal). This lets you spend a high-accuracy model only on the items that need it and a cheaper model elsewhere.
 
-To customize the available models:
+To customize the available models, list the models you want in `cdk/lib/parameter.ts`:
 
 ```typescript
 export const parameters = {
   availableModels: [
-    { modelId: "global.anthropic.claude-opus-4-6-v1", displayName: "Claude Opus 4.6 (Global)" },
-    { modelId: "global.anthropic.claude-sonnet-4-6", displayName: "Claude Sonnet 4.6 (Global)" },
-    { modelId: "global.anthropic.claude-haiku-4-5-20251001-v1:0", displayName: "Claude Haiku 4.5 (Global)" },
-    { modelId: "global.anthropic.claude-sonnet-4-20250514-v1:0", displayName: "Claude Sonnet 4 (Global)" },
+    { modelId: "global.anthropic.claude-sonnet-5", displayName: "Claude Sonnet 5 (Global)" },
+    { modelId: "jp.anthropic.claude-haiku-4-5-20251001-v1:0", displayName: "Claude Haiku 4.5 (JP)" },
+    // ... add the models you need
   ],
 };
 ```
@@ -142,6 +134,30 @@ export const parameters = {
   availableModels: [],
 };
 ```
+
+### Registering Prices When You Add a Model
+
+RAPID displays an estimated cost per review on the Web UI, calculated from each model's per-token price. These prices are maintained in a separate file, `review-item-processor/model_config.py` (the `_MODEL_REGISTRY` dictionary). When you add a new model to `availableModels` (or set it as a default model), please also register its input/output token prices in this file. If a model has no entry, it falls back to a default configuration whose prices are `0`, and the estimated cost for that model is displayed as `$0`.
+
+Add an entry to `review-item-processor/model_config.py`, keyed by the model ID and following the existing entries as a reference:
+
+```python
+_MODEL_REGISTRY = {
+    # ...
+    "global.anthropic.claude-sonnet-5": ModelConfig(
+        model_id="global.anthropic.claude-sonnet-5",
+        display_name="Claude Sonnet 5 (Global)",
+        input_per_1m=3.0,    # price per 1,000,000 input tokens (USD)
+        output_per_1m=15.0,  # price per 1,000,000 output tokens (USD)
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+    # ...
+}
+```
+
+For the per-token prices of each Bedrock model, refer to the [Amazon Bedrock pricing page](https://aws.amazon.com/bedrock/pricing/). `input_per_1m` / `output_per_1m` are prices per 1,000,000 (1M) tokens, matching how the pricing page lists them, so you can copy the values directly (for example, `$3.00` per 1M input tokens becomes `input_per_1m=3.0`).
 
 ## Cleanup Details
 

--- a/docs/en/local-development.md
+++ b/docs/en/local-development.md
@@ -145,6 +145,13 @@ To run a single suite:
 npm run test -- "<suite>"
 ```
 
+Frontend (Vitest):
+
+```bash
+cd frontend
+npm test
+```
+
 Review agent (pytest via uv). `pytest` lives in the optional `dev` extra, so it has to be synced once (a plain `uv sync` does not install optional extras):
 
 ```bash

--- a/docs/ja/README_ja.md
+++ b/docs/ja/README_ja.md
@@ -65,9 +65,9 @@ RAPID は AWS のサーバーレスサービス（Amazon CloudFront、API Gatewa
 
 ローカル環境の準備が不要で、AWS CloudShell を使用してブラウザから直接デプロイできる方法です。
 
-1. **Amazon Bedrock モデルの有効化**
+1. **Amazon Bedrock で利用するモデルの確認**
 
-   AWS Management Console から Bedrock モデルアクセスにアクセスし、利用するモデルへのアクセスを有効化してください（モデルの一覧は [AI モデルのカスタマイズ](./deployment-options.md#ai-モデルのカスタマイズ)をご覧ください）。デフォルトではオレゴン (us-west-2) リージョンを使用しますが、`--bedrock-region` オプションで変更可能です。
+   Amazon Bedrock は、スタックをデプロイしたリージョン（AWS CloudShell を開いたリージョン）のものを使用します。デプロイ先のリージョンで対象のモデル（推論プロファイル）が有効になっていることを確認してください。クロスリージョン（`global.` / `us.` / `eu.` / `apac.` / `jp.`）の推論プロファイルを利用する場合は、[AI モデルのカスタマイズ](./deployment-options.md#ai-モデルのカスタマイズ)をご覧ください。
 
 2. **AWS CloudShell を開く**
 
@@ -183,9 +183,10 @@ CDK デプロイ時に以下のパラメータをカスタマイズできます�
 |                        | cognitoDomainPrefix                  | Cognito ドメインのプレフィックス                                                                                                                                       | 自動生成                                  |
 |                        | cognitoSelfSignUpEnabled             | Cognito User Pool のセルフサインアップを有効にするかどうか                                                                                                             | true (有効)                               |
 | **マイグレーション**   | autoMigrate                          | デプロイ時に自動的にデータベースマイグレーションを実行するかどうか                                                                                                     | true (自動実行する)                       |
+| **Bedrock**           | defaultModelId                  | アプリ全体（ドキュメント処理・画像レビュー・チェックリスト生成・曖昧性検出・WebUI の既定）で使う既定の AI モデルを指定します。`availableModels` による項目個別の選択が優先されます。                                                                                                       | global.anthropic.claude-sonnet-5                                                               |
+|                       | availableModels                 | チェックリスト項目ごとに選択できるモデルの一覧を指定します。モデル ID には、デプロイリージョンと整合する推論プロファイルのプレフィックス（`global.` / `jp.` など）が必要です（[AI モデルのカスタマイズ](./deployment-options.md#ai-モデルのカスタマイズ)参照）。空配列 `[]` にするとモデル選択 UI が非表示になります。                                                | Claude Sonnet 5 (Global)・Opus 4.8 / 4.7・Sonnet 4.6・Haiku 4.5 (Global / JP) と Opus 4.6 (Global) |
 | **MCP 機能**           | mcpAdmin                             | MCP ランタイム Lambda 関数に管理者権限を付与するかどうか                                                                                                               | false (無効)                              |
 | **Citations API**      | enableCitations                      | PDF ドキュメントの Citations API を有効にするかどうか ([AWS 発表](https://aws.amazon.com/about-aws/whats-new/2025/06/citations-api-pdf-claude-models-amazon-bedrock/)) | true (有効)                               |
-| **モデル選択**         | availableModels                      | チェックリスト項目ごとに選択可能なモデル一覧。空配列 `[]` に設定するとモデル選択 UI が非表示になる                                                                     | Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5, Claude Sonnet 4 |
 | **ネットワークモード** | s3ApiGatewayFrontend                 | CloudFront の代わりに専用の REGIONAL API Gateway（S3 プロキシ）経由で SPA を配信する。ネットワーク構成は標準のまま。詳細は[閉域網デプロイ](#閉域網デプロイ)をご覧ください。 | false                                     |
 |                        | closedNetwork                        | 完全プライベートモード: 分離サブネット、NAT なし、VPC エンドポイント、PRIVATE API Gateway、Cognito PrivateLink。`s3ApiGatewayFrontend` を含意する。詳細は[閉域網デプロイ](#閉域網デプロイ)をご覧ください。 | false                                     |
 |                        | agentCoreNetworkMode                 | AgentCore Runtime のネットワークモード（`closedNetwork` 時のみ適用）。`PUBLIC` = ランタイムにインターネットあり（MCP/uv 動作）、`VPC` = ランタイム完全分離。呼び出し経路はいずれもプライベート | PUBLIC                                    |
@@ -218,24 +219,19 @@ CDK デプロイ時に以下のパラメータをカスタマイズできます�
 
 ### AI モデルのカスタマイズ
 
-RAPID では Strands エージェントがファイル読み込みなどのツールを使用するため、**ツール使用に対応したモデル**を選択する必要があります。処理に使うモデル（`documentProcessingModelId` / `imageReviewModelId`）と項目ごとの選択リスト（`availableModels`）は `parameter.ts` で変更できます。ツール使用に対応したモデルの一覧、クロスリージョン推論プロファイルに関する注意、設定例は、[AI モデルのカスタマイズ](./deployment-options.md#ai-モデルのカスタマイズ)をご覧ください。
+RAPID では Strands エージェントがファイル読み込みなどのツールを使用するため、**ツール使用に対応したモデル**を選択する必要があります。アプリ全体の既定モデル（`defaultModelId`）と項目ごとの選択リスト（`availableModels`）は `parameter.ts` で変更できます。チェック項目にモデルが選択されていない場合、審査は既定モデルにフォールバックします。同梱モデルの一覧、リージョンと推論プロファイルに関する注意、設定例、モデル追加時の単価の登録方法は、[AI モデルのカスタマイズ](./deployment-options.md#ai-モデルのカスタマイズ)をご覧ください。
 
 ## 料金について
 
 このソリューションでは、インフラ固定費（目安は約 5 ドル/日、約 150 ドル/月。NAT Gateway と Aurora Serverless v2 が主なコスト要因です）に加えて、ドキュメント処理量に応じた Amazon Bedrock の利用料金（従量課金）が発生します。
 
-| モデルの種類                                   | 1 回の審査で扱えるページ数 | コスト例             |
-| ---------------------------------------------- | -------------------------- | -------------------- |
-| 予算重視の軽量モデル（Claude Haiku 4.5 など）  | 約 80〜85 ページ           | 80 ページで約 0.28 ドル  |
-| 高精度大容量モデル（Claude Opus 4.6 など）     | 約 430 ページ              | 400 ページで約 5.75 ドル |
+| モデルの種類                              | 1 回の審査で扱えるページ数（コンテキストウィンドウによる目安） | コスト例                 |
+| ----------------------------------- | -------------------------------- | -------------------- |
+| 予算重視の軽量モデル（Claude Haiku 4.5 など）     | 約 80〜85 ページ                      | 80 ページで約 0.28 ドル     |
+| 高精度大容量モデル（Claude Opus 4.x など）       | 約 430 ページ                        | 400 ページで約 5.75 ドル    |
 
 > [!Important]
-> - **実際のコストは、お手元のサンプルドキュメントでテストして確認してください。** コストはテキスト量、画像の数とサイズ、チェックリストの項目数により大きく変動します（ページ数は目安のみです）。
-> - **エージェント機能**（Knowledge Bases、Code Interpreter など）を持つ項目は、最大 10 倍のコストがかかることがあります。
-> - 詳細な料金とトークン使用量は、審査結果画面で確認できます。
-> - Amazon Bedrock Converse API には 4.5 MB のファイルサイズ制限があります。
->
-> 最新の料金情報については、[Amazon Bedrock 料金ページ](https://aws.amazon.com/jp/bedrock/pricing/)をご覧ください。
+> 実際のコストは、お手元のサンプルドキュメントでテストして確認してください。コストはテキスト量、画像の数とサイズ、チェックリストの項目数、ツール（Knowledge Bases、Code Interpreter など）の利用状況によって大きく変動します。審査結果画面に表示される料金は、その 1 回の審査のトークン利用量のみに基づく推定値であり、実際の費用と一致しない場合があります。
 
 ## ユーザー権限と管理者セットアップ
 

--- a/docs/ja/deployment-options.md
+++ b/docs/ja/deployment-options.md
@@ -40,6 +40,8 @@ wget -O - https://raw.githubusercontent.com/aws-samples/review-and-assessment-po
 | `--branch`                       | デプロイするブランチ名を指定します。                                                                                                        |
 | `--tag`                          | デプロイする特定の Git タグを指定します。                                                                                                   |
 
+> [!Note]
+> 旧オプション `--document-model` と `--image-model` は非推奨であり、将来のリリースで削除されます。後方互換のため引き続き受け付けますが、いずれも単一の `defaultModelId` パラメータに統合されました。代わりに `--default-model` を使用してください。
 
 ## 閉域網デプロイ
 
@@ -83,55 +85,45 @@ CloudShell スクリプトのオプションで指定する場合:
 
 このアプリケーションは Strands エージェントがファイル読み込みなどのツールを使用するため、**ツール使用に対応したモデル**を選択する必要があります。
 
-**ツール使用対応モデルの例**:
+**ツール使用対応モデルの例**（`availableModels` に既定で含まれるモデル）:
 
-- `global.anthropic.claude-opus-4-6-v1` (Claude Opus 4.6 Global)
-- `global.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6 Global)
-- `us.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6 US)
-- `eu.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6 EU)
-- `jp.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6 JP)
-- `global.anthropic.claude-haiku-4-5-20251001-v1:0` (Claude Haiku 4.5 Global)
-- `global.anthropic.claude-opus-4-5-20251101-v1:0` (Claude Opus 4.5 Global)
-- `global.anthropic.claude-sonnet-4-5-20250929-v1:0` (Claude Sonnet 4.5 Global)
-- `us.anthropic.claude-sonnet-4-5-20250929-v1:0` (Claude Sonnet 4.5 US)
-- `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` (Claude Sonnet 4.5 EU)
-- `jp.anthropic.claude-sonnet-4-5-20250929-v1:0` (Claude Sonnet 4.5 JP)
-- `global.anthropic.claude-sonnet-4-20250514-v1:0` (Claude Sonnet 4 Global)
-- `us.anthropic.claude-sonnet-4-20250514-v1:0` (Claude Sonnet 4 US)
-- `eu.anthropic.claude-sonnet-4-20250514-v1:0` (Claude Sonnet 4 EU)
-- `apac.anthropic.claude-sonnet-4-20250514-v1:0` (Claude Sonnet 4 APAC)
-- `mistral.mistral-large-2407-v1:0` (Mistral Large 2)
-- `us.amazon.nova-premier-v1:0` (Amazon Nova Premier)
-- `us.amazon.nova-2-omni-v1:0` (Amazon Nova 2 Omni)
+- `global.anthropic.claude-sonnet-5` (Claude Sonnet 5, Global) — 既定
+- `global.anthropic.claude-opus-4-8` (Claude Opus 4.8, Global)
+- `jp.anthropic.claude-opus-4-8` (Claude Opus 4.8, JP)
+- `global.anthropic.claude-opus-4-7` (Claude Opus 4.7, Global)
+- `jp.anthropic.claude-opus-4-7` (Claude Opus 4.7, JP)
+- `global.anthropic.claude-opus-4-6-v1` (Claude Opus 4.6, Global)
+- `global.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6, Global)
+- `jp.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6, JP)
+- `global.anthropic.claude-haiku-4-5-20251001-v1:0` (Claude Haiku 4.5, Global)
+- `jp.anthropic.claude-haiku-4-5-20251001-v1:0` (Claude Haiku 4.5, JP)
 
 **重要な注意事項**:
 
-- **クロスリージョン推論プロファイル**: クロスリージョン推論を利用する場合は、`us.`、`eu.`、`apac.` などの地域プレフィックス付きモデル ID が必須です
-- **公式ドキュメント**: [Amazon Bedrock でサポートされているモデルと機能](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html)
+- **クロスリージョン推論プロファイル**: クロスリージョン推論を利用する場合は、モデル ID に地域プレフィックス（`global.`、`us.`、`eu.`、`apac.`、`jp.`）が必須で、プレフィックスはスタック（Amazon Bedrock）をデプロイするリージョンと整合している必要があります。例えば **us-east-1** のデプロイで `jp.*` モデルを選択すると、`ValidationException: The provided model identifier is invalid.` で失敗します。なお、本サンプル同梱の `availableModels` リストには `global.` / `jp.` の推論プロファイルのみが含まれます。デプロイ先リージョンで `us.` / `eu.` / `apac.` などが必要な場合はご自身で追加してください。
+- **公式ドキュメント**: [Amazon Bedrock でサポートされているモデルと機能](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html) / [Amazon Bedrock のモデルカード](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html)
 
-**設定例**: `cdk/lib/parameter.ts` ファイルを直接編集してください。
+**設定例（日本国内で推論を行う場合）**: `cdk/lib/parameter.ts` を次のように編集します。Amazon Bedrock はスタックをデプロイしたリージョンのものを使用するため、`jp.` の推論プロファイルを使う場合は、スタックを日本国内のリージョン（東京リージョン `ap-northeast-1`）にデプロイしてください（例: デプロイ前に `CDK_DEFAULT_REGION=ap-northeast-1` を設定します）。
 
 ```typescript
 export const parameters = {
-  documentProcessingModelId: "global.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (Global)
-  bedrockRegion: "us-west-2", // Oregon region
+  defaultModelId: "jp.anthropic.claude-sonnet-4-6", // Claude Sonnet 4.6 (JP)
   // ...
 };
 ```
 
 ### チェックリスト項目ごとのモデル選択
 
-デフォルトでは、各チェックリスト項目に `availableModels` リストから特定の AI モデルを割り当てることができます。デフォルトのモデルセットには Claude Opus 4.6、Sonnet 4.6、Haiku 4.5、Sonnet 4 (Global) が含まれています。項目にモデルが選択されていない場合、ドキュメントには `documentProcessingModelId`（デフォルト: `global.anthropic.claude-sonnet-4-6`）、画像には `imageReviewModelId`（デフォルト: `global.anthropic.claude-sonnet-4-6`）が使用されます。
+デフォルトでは、各チェックリスト項目に `availableModels` リストから特定の AI モデルを割り当てることができます。項目にモデルが選択されていない場合、審査は `defaultModelId` にフォールバックします（モデルはマルチモーダルのため、ドキュメントと画像で同じ既定値を使用します）。これにより、精度が必要な項目にだけ高精度モデルを使い、それ以外には安価なモデルを使う、といった使い分けができます。
 
-利用可能なモデルをカスタマイズするには:
+利用可能なモデルをカスタマイズするには、`cdk/lib/parameter.ts` に必要なモデルを列挙します。
 
 ```typescript
 export const parameters = {
   availableModels: [
-    { modelId: "global.anthropic.claude-opus-4-6-v1", displayName: "Claude Opus 4.6 (Global)" },
-    { modelId: "global.anthropic.claude-sonnet-4-6", displayName: "Claude Sonnet 4.6 (Global)" },
-    { modelId: "global.anthropic.claude-haiku-4-5-20251001-v1:0", displayName: "Claude Haiku 4.5 (Global)" },
-    { modelId: "global.anthropic.claude-sonnet-4-20250514-v1:0", displayName: "Claude Sonnet 4 (Global)" },
+    { modelId: "global.anthropic.claude-sonnet-5", displayName: "Claude Sonnet 5 (Global)" },
+    { modelId: "jp.anthropic.claude-haiku-4-5-20251001-v1:0", displayName: "Claude Haiku 4.5 (JP)" },
+    // ... 必要なモデルを追加してください
   ],
 };
 ```
@@ -143,6 +135,30 @@ export const parameters = {
   availableModels: [],
 };
 ```
+
+### モデルを追加する際の単価の登録
+
+RAPID は、1 回の審査あたりの金額の目安を Web UI に表示します。この金額は、各モデルの単価（トークンあたりの料金）をもとに算出しています。これらの単価は別のファイル `review-item-processor/model_config.py`（`_MODEL_REGISTRY` という辞書）で管理しています。`availableModels` に新しいモデルを追加する場合（または既定モデルとして設定する場合）は、このファイルにもそのモデルの入力・出力トークンの単価を登録してください。単価が未登録のモデルは、単価が `0` の既定設定にフォールバックし、そのモデルの推定金額は `$0` と表示されます。
+
+既存のエントリを参考に、`review-item-processor/model_config.py` へモデル ID をキーとしたエントリを追加します。
+
+```python
+_MODEL_REGISTRY = {
+    # ...
+    "global.anthropic.claude-sonnet-5": ModelConfig(
+        model_id="global.anthropic.claude-sonnet-5",
+        display_name="Claude Sonnet 5 (Global)",
+        input_per_1m=3.0,    # 入力 1,000,000 トークンあたりの単価（USD）
+        output_per_1m=15.0,  # 出力 1,000,000 トークンあたりの単価（USD）
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+    # ...
+}
+```
+
+Bedrock 上の各モデルのトークン単価は、[Amazon Bedrock 料金ページ](https://aws.amazon.com/bedrock/pricing/)をご参照ください。`input_per_1m` / `output_per_1m` は 1,000,000（1M）トークンあたりの単価で、料金ページの表記と揃えているため、値をそのまま登録できます（例: 入力 100 万トークンあたり `$3.00` の場合は `input_per_1m=3.0` になります）。
 
 ## 後片付けの詳細
 

--- a/docs/ja/local-development.md
+++ b/docs/ja/local-development.md
@@ -145,6 +145,13 @@ npm test
 npm run test -- "<suite>"
 ```
 
+フロントエンド（Vitest）:
+
+```bash
+cd frontend
+npm test
+```
+
 審査エージェント（uv 経由の pytest）。`pytest` はオプションの `dev` extra に含まれるため、一度だけ同期が必要です（素の `uv sync` はオプションの extra をインストールしません）:
 
 ```bash

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,12 +41,15 @@
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "fast-check": "^3.23.2",
+        "jsdom": "^25.0.1",
         "postcss": "^8.4.32",
         "prettier": "^3.1.1",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.2.2",
-        "vite": "^6.4.2"
+        "vite": "^6.4.2",
+        "vitest": "^3.2.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -59,6 +62,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@aws-amplify/analytics": {
       "version": "7.0.93",
@@ -1650,6 +1674,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4281,6 +4420,24 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4653,6 +4810,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xstate/react": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.2.2.tgz",
@@ -4695,6 +4967,16 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -4798,6 +5080,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/attr-accept": {
       "version": "2.2.5",
@@ -4999,6 +5298,30 @@
         "isarray": "^1.0.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5044,6 +5367,23 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5088,6 +5428,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -5200,6 +5550,19 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -5266,10 +5629,45 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5297,6 +5695,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
@@ -5310,11 +5715,31 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -5368,6 +5793,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -5388,6 +5828,75 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
       "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -5642,6 +6151,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5649,6 +6168,39 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5841,6 +6393,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -5906,12 +6475,51 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -6004,6 +6612,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -6026,6 +6647,35 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -6085,12 +6735,53 @@
       "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
       "license": "CC0-1.0"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
       "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/i18next": {
@@ -6129,6 +6820,19 @@
       "integrity": "sha512-mHZxNx1Lq09xt5kCauZ/4bsXOEA2pfpwSoU11/QTJB+pD94iONFwp+ohqi///PwiFvjFOxe1akYCdHyFo1ng5Q==",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/idb": {
@@ -6331,6 +7035,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-unsafe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
@@ -6400,6 +7111,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -6527,6 +7279,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowlight": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
@@ -6551,6 +7310,26 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6569,6 +7348,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -6654,6 +7456,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6777,6 +7586,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6849,6 +7671,23 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -7179,6 +8018,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qrcode": {
       "version": "1.5.0",
@@ -7616,6 +8472,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7644,6 +8507,26 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7688,6 +8571,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7725,6 +8615,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -7826,6 +8730,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strnum": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
@@ -7896,6 +8820,13 @@
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-scrollbar": {
       "version": "3.1.0",
@@ -7977,6 +8908,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -8020,6 +8965,56 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8029,6 +9024,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8307,6 +9328,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.4.5",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
@@ -8334,12 +9378,159 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -8360,6 +9551,23 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -8457,6 +9665,38 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -8471,6 +9711,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xstate": {
       "version": "4.38.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "format": "prettier --write \"**/*.{ts,js,json,md,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md,yml,yaml}\""
   },
@@ -45,11 +47,14 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "fast-check": "^3.23.2",
+    "jsdom": "^25.0.1",
     "postcss": "^8.4.32",
     "prettier": "^3.1.1",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.2.2",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^3.2.2"
   }
 }

--- a/frontend/src/features/checklist/components/ModelSelector.tsx
+++ b/frontend/src/features/checklist/components/ModelSelector.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { HiChevronDown, HiCheck } from "react-icons/hi";
 import { useAvailableModels } from "../hooks/useCheckListItemQueries";
 import { useUpdateCheckListItemModel } from "../hooks/useCheckListItemMutations";
+import { formatModelLabel } from "../utils/modelLabel";
 
 interface ModelSelectorProps {
   setId: string;
@@ -27,12 +28,16 @@ export default function ModelSelector({
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const currentModel = models.find((m) => m.modelId === currentModelId);
-  const defaultModel = models.find((m) => m.modelId === defaultModelId);
-  const defaultLabel = defaultModel
-    ? `${t("checklist.modelDefault")} (${defaultModel.displayName})`
-    : t("checklist.modelDefault");
-  const displayName = currentModel?.displayName ?? defaultLabel;
+  const defaultWord = t("checklist.modelDefault");
+  // モデル名整形は単一の整形器 `formatModelLabel` に集約する（二重括弧解消）。
+  // 既定ラベル: 明示指定なし扱いで `デフォルト: <既定 displayName>`（既定解決不可なら `デフォルト`）。
+  const defaultLabel = formatModelLabel(undefined, models, defaultModelId, {
+    defaultWord,
+  });
+  // トリガ表示: 明示指定があればその displayName、無ければ既定ラベル。
+  const triggerLabel = formatModelLabel(currentModelId, models, defaultModelId, {
+    defaultWord,
+  });
 
   const handleSelect = async (modelId: string | null) => {
     setIsOpen(false);
@@ -80,23 +85,7 @@ export default function ModelSelector({
         aria-label={t("checklist.modelSelector")}
         aria-haspopup="listbox"
         aria-expanded={isOpen}>
-        <span className="text-right leading-tight">
-          {isDefault ? (
-            <>
-              {t("checklist.modelDefault")}
-              {defaultModel && (
-                <>
-                  <br />
-                  <span className="text-[10px] text-aws-font-color-gray">
-                    ({defaultModel.displayName})
-                  </span>
-                </>
-              )}
-            </>
-          ) : (
-            currentModel?.displayName
-          )}
-        </span>
+        <span className="text-right leading-tight">{triggerLabel}</span>
         <HiChevronDown className="h-3 w-3 flex-shrink-0" />
       </button>
 
@@ -117,17 +106,7 @@ export default function ModelSelector({
             <HiCheck
               className={`h-4 w-4 flex-shrink-0 ${isDefault ? "text-aws-sea-blue-light" : "invisible"}`}
             />
-            <span>
-              {t("checklist.modelDefault")}
-              {defaultModel && (
-                <>
-                  <br />
-                  <span className="text-xs font-normal text-aws-font-color-gray">
-                    ({defaultModel.displayName})
-                  </span>
-                </>
-              )}
-            </span>
+            <span>{defaultLabel}</span>
           </li>
 
           {/* 区切り線 */}

--- a/frontend/src/features/checklist/utils/modelLabel.test.ts
+++ b/frontend/src/features/checklist/utils/modelLabel.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import type { ModelInfo } from "../types";
+import { formatModelLabel, type ModelLabelText } from "./modelLabel";
+
+/**
+ * Model label formatting
+ *
+ * formatModelLabel は表示用ラベルを次の 4 分岐で決定的に整形する。整形器は
+ * いかなる分岐でも「追加のラップ括弧」を付けないため、入力自体がネスト括弧
+ * (`((` / `))`) を含まない限り、出力にもネスト括弧は生じない。
+ *
+ *  - (a) 既知 modelId           → その displayName をそのまま
+ *  - (b) 明示なし・既定解決可    → `${defaultWord}: ${defaultDisplayName}`
+ *  - (c) 明示なし・既定解決不可  → `${defaultWord}`
+ *  - (d) 不明な非空 modelId      → modelId をそのまま
+ *
+ * 本テストは「整形器がネスト括弧を導入しない」ことを検証するため、すべての文字列
+ * 入力をネスト括弧を含まない (単一括弧群は許容する) ように制約する。RAPID の実際の
+ * displayName は `Claude Opus 4.7 (Global)` のように単一括弧群のみを含むため、この
+ * 制約は実データの前提と一致する。
+ */
+
+/** ネスト括弧 `((` / `))` を含まないことを判定するヘルパ。 */
+const hasNoNestedParens = (s: string): boolean =>
+  !s.includes("((") && !s.includes("))");
+
+/**
+ * displayName のジェネレータ。
+ * - 意図的に `(Global)` 等の単一括弧群を含む curated 値を混ぜる (二重括弧回避の検証の核心)。
+ * - ランダム文字列も混ぜるが、ネスト括弧 `((` / `))` を含むものは除外する
+ *   (整形器の不変条件は「displayName 自身が単一括弧群のみ」を前提とするため)。
+ */
+const arbDisplayName: fc.Arbitrary<string> = fc.oneof(
+  fc.constantFrom(
+    "Claude Opus 4.7 (Global)",
+    "Claude Sonnet 4 (Global)",
+    "Amazon Nova Pro",
+    "GPT-4o",
+    "Model (US) (beta)", // 複数の単一括弧群を持つが `((` / `))` は無い
+    "" // 空 displayName エッジ
+  ),
+  fc.string().filter(hasNoNestedParens)
+);
+
+/**
+ * modelId / defaultModelId に使う「非空・ネスト括弧なし」文字列。
+ * 現実の id は括弧を含まないため、括弧そのものを除外して realistic に保つ。
+ */
+const arbNonEmptyId: fc.Arbitrary<string> = fc.oneof(
+  fc.constantFrom(
+    "global.anthropic.claude-sonnet-4-20250514-v1:0",
+    "us.amazon.nova-pro-v1:0",
+    "anthropic.claude-3-haiku-20240307-v1:0"
+  ),
+  fc
+    .string({ minLength: 1 })
+    .filter((s) => s.length > 0 && !s.includes("(") && !s.includes(")"))
+);
+
+/** defaultWord (i18n の "デフォルト" 相当)。空文字も含め、ネスト括弧は除外。 */
+const arbDefaultWord: fc.Arbitrary<string> = fc.oneof(
+  fc.constantFrom("デフォルト", "Default", ""),
+  fc.string().filter(hasNoNestedParens)
+);
+
+const arbModels: fc.Arbitrary<ModelInfo[]> = fc.array(
+  fc.record({ modelId: arbNonEmptyId, displayName: arbDisplayName }),
+  { maxLength: 6 }
+);
+
+/**
+ * 1 ケース分の入力 (models / modelId / defaultModelId / defaultWord) を生成する。
+ * models に依存して「既知 id」を選ぶため fc.chain で段階生成する。modelId は
+ * fc.oneof(既知 id, null, undefined, "", 一覧外の非空 id) を、defaultModelId は
+ * fc.oneof(既知 id, null, 一覧外 id) を網羅し、(a)〜(d) の全分岐を踏む。
+ */
+const arbCase = arbModels.chain((models) => {
+  const knownIds = models.map((m) => m.modelId);
+
+  const modelIdArb: fc.Arbitrary<string | null | undefined> = fc.oneof(
+    ...(knownIds.length > 0 ? [fc.constantFrom(...knownIds)] : []),
+    fc.constant(null),
+    fc.constant(undefined),
+    fc.constant(""),
+    arbNonEmptyId // 多くの場合は一覧外 (分岐 d)。偶発的に一致しても oracle が吸収する
+  );
+
+  const defaultModelIdArb: fc.Arbitrary<string | null> = fc.oneof(
+    ...(knownIds.length > 0 ? [fc.constantFrom(...knownIds)] : []),
+    fc.constant(null),
+    arbNonEmptyId // 一覧外 id → 既定解決不可 (分岐 c) を踏む
+  );
+
+  return fc.record({
+    models: fc.constant(models),
+    modelId: modelIdArb,
+    defaultModelId: defaultModelIdArb,
+    defaultWord: arbDefaultWord,
+  });
+});
+
+/**
+ * 独立 oracle: 出力規約をそのまま再記述する。`Array.prototype.find`
+ * (標準ライブラリ) のみを使い、実装の find 一致セマンティクス (最初の一致を採用) を
+ * 反映する。実装と同じ規約を別実装で書くことで分岐の期待値を固定する。
+ */
+const expectedLabel = (
+  modelId: string | null | undefined,
+  models: ModelInfo[],
+  defaultModelId: string | null,
+  defaultWord: string
+): string => {
+  const hasExplicit = typeof modelId === "string" && modelId.length > 0;
+  if (hasExplicit) {
+    const hit = models.find((m) => m.modelId === modelId);
+    return hit ? hit.displayName : (modelId as string);
+  }
+  const def =
+    defaultModelId != null
+      ? models.find((m) => m.modelId === defaultModelId)
+      : undefined;
+  return def ? `${defaultWord}: ${def.displayName}` : defaultWord;
+};
+
+describe("formatModelLabel", () => {
+  it("never throws, never introduces nested parens, and matches the documented (a)-(d) branches", () => {
+    fc.assert(
+      fc.property(
+        arbCase,
+        ({ models, modelId, defaultModelId, defaultWord }) => {
+          const text: ModelLabelText = { defaultWord };
+
+          // (0) 例外を投げない (要件: 安定フォールバック)
+          let out!: string;
+          expect(() =>
+            formatModelLabel(modelId, models, defaultModelId, text)
+          ).not.toThrow();
+          out = formatModelLabel(modelId, models, defaultModelId, text);
+
+          // 出力は常に string
+          expect(typeof out).toBe("string");
+
+          // 整形器はラップ括弧を追加しないため、ネスト括弧は生じない
+          expect(out.includes("((")).toBe(false);
+          expect(out.includes("))")).toBe(false);
+
+          // documented な (a)〜(d) 分岐の期待値と一致する
+          expect(out).toBe(
+            expectedLabel(modelId, models, defaultModelId, defaultWord)
+          );
+
+          // 各分岐ごとの構造的な不変条件を独立に確認する
+          const hasExplicit = typeof modelId === "string" && modelId.length > 0;
+          if (hasExplicit) {
+            const hit = models.find((m) => m.modelId === modelId);
+            if (hit) {
+              // (a) 既知 id → displayName 直返し (装飾なし)
+              expect(out).toBe(hit.displayName);
+            } else {
+              // (d) 不明な非空 id → 生 id 直返し (情報欠落回避)
+              expect(out).toBe(modelId);
+            }
+          } else {
+            const def =
+              defaultModelId != null
+                ? models.find((m) => m.modelId === defaultModelId)
+                : undefined;
+            if (def) {
+              // (b) 既定解決可 → `${defaultWord}: ${defaultDisplayName}`
+              expect(out).toBe(`${defaultWord}: ${def.displayName}`);
+              expect(out.startsWith(`${defaultWord}: `)).toBe(true);
+              expect(out.endsWith(def.displayName)).toBe(true);
+            } else {
+              // (c) 既定解決不可 → defaultWord (安定フォールバック)
+              expect(out).toBe(defaultWord);
+            }
+          }
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+
+  it('a displayName containing a single parenthesis group (e.g. "(Global)") is returned verbatim without being wrapped into nested parens', () => {
+    const arb = fc.record({
+      modelId: arbNonEmptyId,
+      displayName: fc.constantFrom(
+        "Claude Opus 4.7 (Global)",
+        "Claude Sonnet 4 (Global)",
+        "Model (US) (beta)"
+      ),
+      defaultWord: arbDefaultWord,
+    });
+
+    fc.assert(
+      fc.property(arb, ({ modelId, displayName, defaultWord }) => {
+        const models: ModelInfo[] = [{ modelId, displayName }];
+        const text: ModelLabelText = { defaultWord };
+
+        // 既知 id (分岐 a): displayName をそのまま返し、追加括弧で包まない
+        const knownOut = formatModelLabel(modelId, models, null, text);
+        expect(knownOut).toBe(displayName);
+        expect(knownOut.includes("((")).toBe(false);
+        expect(knownOut.includes("))")).toBe(false);
+
+        // 既定解決 (分岐 b): `${defaultWord}: ${displayName}` で単一括弧のまま
+        const defaultOut = formatModelLabel(null, models, modelId, text);
+        expect(defaultOut).toBe(`${defaultWord}: ${displayName}`);
+        expect(defaultOut.includes("((")).toBe(false);
+        expect(defaultOut.includes("))")).toBe(false);
+      }),
+      { numRuns: 200 }
+    );
+  });
+});

--- a/frontend/src/features/checklist/utils/modelLabel.ts
+++ b/frontend/src/features/checklist/utils/modelLabel.ts
@@ -1,0 +1,40 @@
+import type { ModelInfo } from "../types";
+
+/** i18n 文言は呼び出し側から注入し、関数自体は React/i18n 非依存にする。 */
+export interface ModelLabelText {
+  /** 既定マーカー（既存 `checklist.modelDefault` = "デフォルト"）。 */
+  defaultWord: string;
+}
+
+/**
+ * モデル名表示の単一正規整形器（共有純粋関数）。
+ *
+ * 出力規約:
+ *  - (a) 既知 modelId           → その displayName をそのまま
+ *  - (b) 明示なし・既定解決可    → `${defaultWord}: ${defaultDisplayName}`（ラップ括弧を追加しない）
+ *  - (c) 明示なし・既定解決不可  → `${defaultWord}`（安定フォールバック・例外を投げない）
+ *  - (d) 不明な非空 modelId      → modelId をそのまま（情報欠落回避）
+ *
+ * いずれの分岐でも整形器が括弧を追加しないため、出力に `((` / `))` の入れ子は生じない。
+ * displayName 自身は単一括弧群のみを含むため安全。
+ */
+export function formatModelLabel(
+  modelId: string | null | undefined,
+  models: ModelInfo[],
+  defaultModelId: string | null,
+  text: ModelLabelText
+): string {
+  const hasExplicit = typeof modelId === "string" && modelId.length > 0;
+
+  if (hasExplicit) {
+    const hit = models.find((m) => m.modelId === modelId);
+    return hit ? hit.displayName : (modelId as string); // 既知 → displayName / 不明 → 生 id
+  }
+
+  // 明示なし → 既定を解決
+  const def =
+    defaultModelId != null
+      ? models.find((m) => m.modelId === defaultModelId)
+      : undefined;
+  return def ? `${text.defaultWord}: ${def.displayName}` : text.defaultWord;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/review-item-processor/Dockerfile
+++ b/review-item-processor/Dockerfile
@@ -29,7 +29,12 @@ COPY . ./
 
 EXPOSE 8080
 
-# uses the pre-built venv as-is; UV_OFFLINE forbids any network access.
+# 依存関係はイメージビルド時に uv sync --frozen で確定済みのため、起動時の
+# 再同期とネットワーク取得を無効化する。VPC 配置（特に閉域）では起動時に
+# インターネットへ出られず失敗するため必須で、それ以外の構成でも無害。
+# Dependencies are locked into the image at build time, so disable runtime
+# re-sync and network fetches. Required when the runtime has no internet
+# (VPC/closed placement) and harmless otherwise.
 ENV UV_NO_SYNC=1 \
     UV_OFFLINE=1
 

--- a/review-item-processor/agent.py
+++ b/review-item-processor/agent.py
@@ -1,4 +1,5 @@
 import hashlib
+import itertools
 import json
 import os
 import re
@@ -8,16 +9,18 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import boto3
+from logger import logger
+from model_config import ModelConfig
 from strands import Agent
 from strands.models import BedrockModel
 from strands.models.model import CacheConfig
-from strands.tools.mcp import MCPClient
-from strands_tools import file_read, image_reader
-
-from logger import logger
-from model_config import ModelConfig
+from strands.types.tools import AgentTool
 from tool_history_collector import ToolHistoryCollector
 from tools.factory import create_custom_tools
+from tools.file_access import (
+    create_bounded_file_read_tool,
+    create_bounded_image_reader_tool,
+)
 
 
 class ReviewMetaTracker:
@@ -42,8 +45,10 @@ class ReviewMetaTracker:
             f"Token usage from metrics: input={input_tokens}, output={output_tokens}, total={total_tokens}"
         )
 
-        input_cost = (input_tokens / 1000) * self.model.input_per_1k
-        output_cost = (output_tokens / 1000) * self.model.output_per_1k
+        # Pricing is per 1,000,000 (1M) tokens (see model_config.py), so divide
+        # the token counts by 1M to get the USD cost.
+        input_cost = (input_tokens / 1_000_000) * self.model.input_per_1m
+        output_cost = (output_tokens / 1_000_000) * self.model.output_per_1m
         total_cost = input_cost + output_cost
 
         return {
@@ -54,8 +59,8 @@ class ReviewMetaTracker:
             "output_cost": output_cost,
             "total_cost": total_cost,
             "pricing": {
-                "input_per_1k": self.model.input_per_1k,
-                "output_per_1k": self.model.output_per_1k,
+                "input_per_1m": self.model.input_per_1m,
+                "output_per_1m": self.model.output_per_1m,
             },
             "duration_seconds": round(duration, 2),
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -76,8 +81,10 @@ IMAGE_FILE_EXTENSIONS = [
 PDF_FILE_EXTENSIONS = [".pdf"]
 
 # Default model IDs
-DEFAULT_DOCUMENT_MODEL_ID = "global.anthropic.claude-sonnet-4-6"  # For all processing
-DEFAULT_IMAGE_MODEL_ID = "global.anthropic.claude-sonnet-4-6"  # For image processing (same as document by default)
+DEFAULT_DOCUMENT_MODEL_ID = (
+    "global.anthropic.claude-sonnet-5"  # For all processing
+)
+DEFAULT_IMAGE_MODEL_ID = "global.anthropic.claude-sonnet-5"  # For image processing (same as document by default)
 
 # Get model IDs from environment variables with fallback to defaults
 DOCUMENT_MODEL_ID = os.environ.get(
@@ -102,7 +109,6 @@ NOVA_PREMIER_MODEL_ID = IMAGE_MODEL_ID
 
 # Get environment variables
 AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
-BEDROCK_REGION = os.environ.get("BEDROCK_REGION", "us-west-2")
 ENABLE_CITATIONS = os.environ.get("ENABLE_CITATIONS", "true").lower() == "true"
 # Tool text truncate length
 TOOL_TEXT_TRUNCATE_LENGTH = 500
@@ -150,22 +156,6 @@ def _should_use_document_block(
 
     model = ModelConfig.create(model_id)
     return ENABLE_CITATIONS and model.supports_document_block
-
-
-def create_mcp_client(mcp_server_cfg: Dict[str, Any]) -> MCPClient:
-    """
-    Create an MCP client for the given server configuration.
-
-    Args:
-        mcp_server_cfg: MCP server configuration
-
-    Returns:
-        MCPClient: Initialized MCP client
-    """
-    logger.info(f"Creating MCP client with config: {mcp_server_cfg}")
-    # TODO
-    # return MCPClient(...)
-    raise NotImplementedError("MCP is handled directly by AgentCore Runtime")
 
 
 def sanitize_file_name(filename: str) -> str:
@@ -325,6 +315,14 @@ def _execute_review_core(
 
     else:
         # File read tool path (images or non-citation support)
+        # 素の file_read / image_reader を無制限で渡すと LFI に至るため、このジョブの
+        # 対象ファイルが置かれた作業ディレクトリ（temp_dir）配下に束縛したラッパーに
+        # 差し替える。allowed_dirs は file_paths の親ディレクトリ集合から導出する。
+        allowed_dirs = sorted(
+            {os.path.dirname(os.path.realpath(p)) for p in file_paths}
+        )
+        bounded_file_read = create_bounded_file_read_tool(allowed_dirs)
+
         if has_images:
             prompt = get_image_review_prompt(
                 language_name,
@@ -334,7 +332,10 @@ def _execute_review_core(
                 toolConfiguration,
                 feedback_summary,
             )
-            tools = [file_read, image_reader]
+            # image_reader も file_read と同じ allowed_dirs に束縛する
+            # （素の image_reader は ~ 展開・任意パス読み取り可）。
+            bounded_image_reader = create_bounded_image_reader_tool(allowed_dirs)
+            tools = [bounded_file_read, bounded_image_reader]
             review_type = "IMAGE"
         else:
             prompt = get_document_review_prompt(
@@ -345,7 +346,7 @@ def _execute_review_core(
                 tool_config=toolConfiguration,
                 feedback_summary=feedback_summary,
             )
-            tools = [file_read]
+            tools = [bounded_file_read]
             review_type = "PDF"
 
         system_prompt = (
@@ -373,46 +374,42 @@ def _execute_review_core(
     return result
 
 
-def list_tools_sync(client: MCPClient) -> List[Dict[str, Any]]:
-    """
-    List available tools from an MCP client.
-
-    Args:
-        client: MCP client
-
-    Returns:
-        List of tool definitions
-    """
-    logger.debug("Listing tools from MCP client")
-    try:
-        # Use the built-in list_tools_sync method directly
-        tools = client.list_tools_sync()
-        logger.debug(f"Found {len(tools)} tools from MCP client")
-        return tools
-    except Exception as e:
-        logger.error(f"Error listing tools from MCP client: {e}")
-        return []
-
-
 # Agent execution functions
 def _run_agent_with_file_read_tool(
     prompt: str,
     file_paths: List[str],
     model_id: str = DOCUMENT_MODEL_ID,
     system_prompt: str = "You are an expert document reviewer.",
-    temperature: float = 0.0,
     base_tools: Optional[List[Any]] = None,
     toolConfiguration: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Run Strands agent with traditional file_read approach"""
     logger.debug(f"Running Strands agent with {len(file_paths)} files")
-    logger.debug(f"Tool configuration: {toolConfiguration}")
+    # toolConfiguration には MCP 資格情報（headers/env/oauthScopes、資格情報を埋め込み
+    # うる url）が含まれるため値をログ出力しない。有無とトップレベルキーのみを記録する
+    # （index.py の修正パターンに合わせる）。
+    if isinstance(toolConfiguration, dict):
+        logger.debug(
+            f"Tool configuration present; keys={sorted(toolConfiguration.keys())}"
+        )
+    else:
+        logger.debug(
+            f"Tool configuration present={toolConfiguration is not None}"
+        )
 
     meta_tracker = ReviewMetaTracker(model_id)
     history_collector = ToolHistoryCollector(truncate_length=TOOL_TEXT_TRUNCATE_LENGTH)
 
-    # Use provided base tools or default to file_read
-    tools_to_use = base_tools if base_tools else [file_read]
+    # Use provided base tools or default to a bounded file_read.
+    # file_read を直接 import しなくなったため、フォールバックも file_paths の親
+    # ディレクトリに束縛した安全版を使う（無制限 file_read は使わない）。
+    if base_tools:
+        tools_to_use = base_tools
+    else:
+        fallback_allowed_dirs = sorted(
+            {os.path.dirname(os.path.realpath(p)) for p in file_paths}
+        )
+        tools_to_use = [create_bounded_file_read_tool(fallback_allowed_dirs)]
 
     # Add custom tools based on configuration
     custom_tools = create_custom_tools(toolConfiguration)
@@ -430,11 +427,16 @@ def _run_agent_with_file_read_tool(
     model_supports_cache = model.supports_caching
     logger.debug(f"Model {model_id} caching support: {model_supports_cache}")
 
-    # Configure BedrockModel with conditional caching
+    # Configure BedrockModel with conditional caching.
+    # Sampling params (temperature etc.) are intentionally not sent: recent
+    # Claude models (Sonnet 5, Opus 4.7+) reject them with ValidationException,
+    # and AWS recommends omitting them entirely.
+    # sampling パラメータ（temperature 等）は意図的に送信しません。新しい Claude
+    # モデル（Sonnet 5 / Opus 4.7 以降）は ValidationException で拒否するため、
+    # AWS の推奨どおりリクエストから省略します。
     bedrock_config = {
         "model_id": model_id,
-        "region_name": BEDROCK_REGION,
-        "temperature": temperature,
+        "region_name": AWS_REGION,
         "streaming": False,  # Always disable streaming since this app doesn't use streaming
     }
 
@@ -489,7 +491,6 @@ def _run_agent_with_document_block(
     file_paths: List[str],
     model_id: str = DOCUMENT_MODEL_ID,
     system_prompt: str = "You are an expert document reviewer.",
-    temperature: float = 0.0,
     toolConfiguration: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -541,13 +542,40 @@ def _run_agent_with_document_block(
 
         content.append(doc_block)
 
+    # 文書ブロック群と項目別プロンプトの間に明示 cachePoint を置き、キャッシュ
+    # 境界を「文書まで」に固定する。auto 戦略の自動配置はメッセージ末尾
+    # （= 項目ごとに変わるプロンプトの後）に入るため、項目間でプレフィックスが
+    # 一致せず文書キャッシュが共有されない。手動配置は strands-agents 1.52.0 の
+    # honor 挙動（_honor_placed_cache_point）で尊重される（pyproject の下限固定と
+    # 対）。同一文書・同一モデル・同一ツール構成の審査項目間で、2 項目目以降は
+    # 文書プレフィックスをキャッシュから読める。モデルが最小トークン数
+    # （例: 4.5 世代 Claude は 4,096）未満のプレフィックスは無害に不発となる。
+    # Place an explicit cachePoint between the document blocks and the
+    # per-item prompt so the cache boundary ends at the documents. The auto
+    # strategy would append the cachePoint at the end of the message (after
+    # the per-item prompt), so prefixes would differ between review items and
+    # the document cache would never be shared. Manually placed points are
+    # honored by strands-agents >= 1.52.0 (_honor_placed_cache_point; the
+    # pyproject floor is pinned accordingly). Review items that share the
+    # same documents, model, and tool configuration can then read the
+    # document prefix from cache from the second item onward. Prefixes below
+    # the model's minimum token count (e.g. 4,096 for 4.5-generation Claude)
+    # are harmlessly not cached.
+    if model.supports_caching and content:
+        content.append({"cachePoint": {"type": "default"}})
+
     content.append({"text": prompt})
 
-    # Configure model
+    # Configure model.
+    # Sampling params (temperature etc.) are intentionally not sent: recent
+    # Claude models (Sonnet 5, Opus 4.7+) reject them with ValidationException,
+    # and AWS recommends omitting them entirely.
+    # sampling パラメータ（temperature 等）は意図的に送信しません。新しい Claude
+    # モデル（Sonnet 5 / Opus 4.7 以降）は ValidationException で拒否するため、
+    # AWS の推奨どおりリクエストから省略します。
     bedrock_config = {
         "model_id": model_id,
-        "region_name": BEDROCK_REGION,
-        "temperature": temperature,
+        "region_name": AWS_REGION,
         "streaming": False,
     }
 
@@ -723,9 +751,7 @@ def _build_tool_usage_section(
         tool_descriptions.append(
             "- **code_interpreter**: Perform calculations, data analysis, or process structured data"
         )
-        use_cases.append(
-            "- Perform calculations or data analysis → Use code_interpreter"
-        )
+        use_cases.append("- Perform calculations or data analysis → Use code_interpreter")
 
     # Knowledge Base
     kb_config = tool_config.get("knowledgeBase")
@@ -770,26 +796,6 @@ When calling multiple independent tools, execute them in parallel. Only call too
 """
 
 
-def _build_feedback_section(feedback_summary: Optional[str]) -> str:
-    """Build feedback section for prompt if feedback summary exists"""
-    if not feedback_summary:
-        return ""
-    return f"""
-<HISTORICAL_FEEDBACK>
-**CRITICAL - PAST REVIEWER FEEDBACK**: Previous reviewers provided the following feedback for this specific check item:
-
-{feedback_summary}
-
-**YOU MUST:**
-- Carefully consider this feedback when making your judgment
-- Pay special attention to the issues and patterns mentioned
-- Apply the lessons learned from previous reviews
-
-This feedback represents real-world review experience and should significantly influence your evaluation.
-</HISTORICAL_FEEDBACK>
-"""
-
-
 # Prompt generation functions
 def _get_document_review_prompt_legacy(
     language_name: str,
@@ -810,7 +816,6 @@ def _get_document_review_prompt_legacy(
 }}"""
 
     tool_section = _build_tool_usage_section(tool_config, language_name)
-    feedback_rule = _build_feedback_section(feedback_summary)
 
     return f"""You are an expert document reviewer. Review the attached documents against this check item:
 
@@ -831,7 +836,6 @@ Generate your entire response in {language_name}. Output only the JSON below, en
 <<JSON_END>>
 
 <CRITICAL_RULES>
-{feedback_rule}
 <BASE_JUDGMENT_ON_DOCUMENTS_ONLY>
 **CRITICAL**: Base your judgment ONLY on the provided documents and information obtained through tools.
 Do NOT use your pre-trained general knowledge or make assumptions.
@@ -878,7 +882,6 @@ def _get_document_review_prompt_with_citations(
 }}"""
 
     tool_section = _build_tool_usage_section(tool_config, language_name)
-    feedback_rule = _build_feedback_section(feedback_summary)
 
     return f"""You are an expert document reviewer. Review the attached documents against this check item:
 
@@ -912,7 +915,6 @@ Generate your entire response in {language_name}. Output only the JSON below, en
 Write the explanation field as clear, flowing prose in {language_name}. Include relevant quotes in the citations array.
 
 <CRITICAL_RULES>
-{feedback_rule}
 <BASE_JUDGMENT_ON_DOCUMENTS_ONLY>
 **CRITICAL**: Base your judgment ONLY on the provided documents and information obtained through tools.
 Do NOT use your pre-trained general knowledge or make assumptions.
@@ -999,7 +1001,6 @@ def get_image_review_prompt(
 }}"""
 
     tool_section = _build_tool_usage_section(tool_config, language_name)
-    feedback_rule = _build_feedback_section(feedback_summary)
 
     return f"""
 You are an AI assistant who reviews images.
@@ -1047,7 +1048,6 @@ contain exactly that single index; an empty array means “none used”.
 
 
 <CRITICAL_RULES>
-{feedback_rule}
 <BASE_JUDGMENT_ON_IMAGES_ONLY>
 **CRITICAL**: Base your judgment ONLY on the provided images and information obtained through tools.
 Do NOT use your pre-trained general knowledge or make assumptions.
@@ -1147,7 +1147,7 @@ def process_review_from_s3(
             feedback_summary=feedback_summary,
         )
 
-        logger.info("S3 review completed successfully")
+        logger.info(f"S3 review completed successfully")
         return result
 
     finally:
@@ -1216,7 +1216,7 @@ def process_review_from_local(
         feedback_summary=feedback_summary,
     )
 
-    logger.info("Local review completed successfully")
+    logger.info(f"Local review completed successfully")
     return result
 
 

--- a/review-item-processor/evals/README.md
+++ b/review-item-processor/evals/README.md
@@ -543,17 +543,27 @@ uv run python evals/scripts/run_eval.py [OPTIONS]
 
 **Examples:**
 
+Run comprehensive evaluation (default):
+
 ```bash
-# Run comprehensive evaluation (default)
 uv run python evals/scripts/run_eval.py --suite my_tests/my_suite.json
+```
 
-# Run with verbose output
+Run with verbose output:
+
+```bash
 uv run python evals/scripts/run_eval.py --suite my_tests/my_suite.json --verbose
+```
 
-# Run single test case
+Run a single test case:
+
+```bash
 uv run python evals/scripts/run_eval.py --case my_tests/single_case.json
+```
 
-# Run accuracy-only (faster)
+Run accuracy-only (faster):
+
+```bash
 uv run python evals/scripts/run_eval.py --suite my_tests/my_suite.json --experiment accuracy
 ```
 

--- a/review-item-processor/evals/ja/README.md
+++ b/review-item-processor/evals/ja/README.md
@@ -8,20 +8,20 @@
 
 ## クイックスタート
 
-依存関係をインストール:
+依存関係をインストールします。
 
 ```bash
 cd review-item-processor
 uv sync --extra evals
 ```
 
-事前構築されたデモを実行して動作を確認:
+事前構築されたデモを実行して動作を確認します。
 
 ```bash
 uv run python evals/scripts/run_eval.py --suite ja/examples/floor_plan_hitl_suite.json
 ```
 
-以下のようなメトリクスが表示されます:
+以下のようなメトリクスが表示されます。
 
 - Accuracy: 100%
 - Recall: 100%
@@ -39,20 +39,20 @@ uv run python evals/scripts/run_eval.py --suite ja/examples/floor_plan_hitl_suit
 
 ### 評価とは?
 
-評価は、AI エージェントが正しい判断を下すかどうかをテストします。すべてのドキュメントを手動でチェックする代わりに:
+評価は、AI エージェントが正しい判断を下すかどうかをテストします。すべてのドキュメントを手動でチェックする代わりに、次の手順を実施します。
 
-1. 既知の正解(正解ラベル)を持つテストケースを作成
-2. それらのテストケースでエージェントを実行
-3. エージェントの回答を正解ラベルと比較
-4. パフォーマンスを測定するメトリクスを計算
+1. 既知の正解(正解ラベル)を持つテストケースを作成します。
+2. それらのテストケースでエージェントを実行します。
+3. エージェントの回答を正解ラベルと比較します。
+4. パフォーマンスを測定するメトリクスを計算します。
 
 ### なぜ評価するのか?
 
-本番環境(特に安全性/コンプライアンス)に AI エージェントをデプロイする前に、以下を確認する必要があります:
+本番環境(特に安全性/コンプライアンス)に AI エージェントをデプロイする前に、以下を確認する必要があります。
 
-- すべての重要な問題を検出する(高い再現率)
-- 誤警報が多すぎない(良好な適合率)
-- 不確実な場合にそれを認識する(良好なキャリブレーション)
+- すべての重要な問題を検出できること(高い再現率)
+- 誤警報が多すぎないこと(良好な適合率)
+- 不確実な場合にそれを認識できること(良好なキャリブレーション)
 
 ### 2 種類のメトリクス
 
@@ -92,11 +92,11 @@ uv run python evals/scripts/run_eval.py --suite ja/examples/floor_plan_hitl_suit
 
 **ワークフロー**:
 
-1. agent.py のシステムプロンプトを設計 (役割定義、出力形式、信頼度ガイドライン、クリティカルルール)
-2. eval を実行してプロンプトバリエーションをテスト
-3. メトリクスを分析 (recall, precision, critical errors)
-4. 本番基準を満たすまでプロンプトを改善
-5. エージェントをリリース
+1. agent.py のシステムプロンプトを設計します (役割定義、出力形式、信頼度ガイドライン、クリティカルルール)。
+2. eval を実行してプロンプトバリエーションをテストします。
+3. メトリクスを分析します (recall, precision, critical errors)。
+4. 本番基準を満たすまでプロンプトを改善します。
+5. エージェントをリリースします。
 
 **注**: 非技術者の方は、多くの場合 eval を実行する必要はありません。技術チームがチューニングしたエージェントをそのまま使用します。
 
@@ -267,7 +267,7 @@ Low Quality Count:  0
 
 ### ステップ 1: テストドキュメントの準備
 
-PDF を fixtures ディレクトリにコピー:
+PDF を fixtures ディレクトリにコピーします。
 
 ```bash
 cp your_document.pdf evals/my_tests/fixtures/
@@ -277,13 +277,13 @@ cp your_document.pdf evals/my_tests/fixtures/
 
 ### ステップ 2: テストケース定義の作成
 
-テンプレートをコピーして編集:
+テンプレートをコピーして編集します。
 
 ```bash
 cp evals/my_tests/template.json evals/my_tests/my_suite.json
 ```
 
-`my_tests/my_suite.json`を編集:
+`my_tests/my_suite.json`を編集します。
 
 ```json
 {
@@ -315,11 +315,11 @@ cp evals/my_tests/template.json evals/my_tests/my_suite.json
 
 ### ステップ 3: 正解ラベルの決定
 
-**あなた自身がドキュメントを読んで正しい答えを決定する必要があります**:
+**あなた自身がドキュメントを読んで正しい答えを決定する必要があります**。
 
-1. ドキュメントを注意深く読む
-2. `check_description`の要件と照らし合わせてチェック
-3. 決定: "pass"(準拠) または "fail"(非準拠)
+1. ドキュメントを注意深く読みます。
+2. `check_description`の要件と照らし合わせてチェックします。
+3. "pass"(準拠) または "fail"(非準拠) を決定します。
 
 **例**:
 
@@ -424,7 +424,7 @@ uv run python evals/scripts/run_eval.py --suite my_tests/my_suite.json
 
 #### run_eval.py
 
-コマンドラインから評価を実行:
+コマンドラインから評価を実行します。
 
 ```bash
 uv run python evals/scripts/run_eval.py [OPTIONS]
@@ -432,42 +432,52 @@ uv run python evals/scripts/run_eval.py [OPTIONS]
 
 **オプション:**
 
-- `--suite <path>` - テストスイートを実行(テストケースの配列を含む JSON ファイル)
+- `--suite <path>` - テストスイートを実行します(テストケースの配列を含む JSON ファイル)。
 
   - 例: `--suite my_tests/my_suite.json`
 
-- `--case <path>` - 単一テストケースを実行(単一テストケースを含む JSON ファイル)
+- `--case <path>` - 単一テストケースを実行します(単一テストケースを含む JSON ファイル)。
 
   - 例: `--case my_tests/single_case.json`
 
-- `--experiment <type>` - 実験タイプを選択:
+- `--experiment <type>` - 実験タイプを選択します。
 
   - `accuracy` - 精度とキャリブレーションメトリクスのみ(高速)
   - `tool` - ツール使用効率メトリクスを追加
   - `comprehensive` - 説明品質を含むすべてのメトリクス(デフォルト)
 
-- `--output <path>` - 結果を特定のファイルに保存
+- `--output <path>` - 結果を特定のファイルに保存します。
 
   - デフォルト: `results/results_TIMESTAMP.json`
   - 例: `--output my_results.json`
 
-- `--verbose` - 各テストケースの詳細出力を表示
-  - エージェントの出力、信頼度、説明を表示
-  - 偽陰性/偽陽性のデバッグに便利
+- `--verbose` - 各テストケースの詳細出力を表示します。
+  - エージェントの出力、信頼度、説明を表示します。
+  - 偽陰性/偽陽性のデバッグに便利です。
 
 **例:**
 
+包括的評価を実行(デフォルト):
+
 ```bash
-# 包括的評価を実行(デフォルト)
 uv run python evals/scripts/run_eval.py --suite my_tests/my_suite.json
+```
 
-# 詳細出力で実行
+詳細出力で実行:
+
+```bash
 uv run python evals/scripts/run_eval.py --suite my_tests/my_suite.json --verbose
+```
 
-# 単一テストケースを実行
+単一テストケースを実行:
+
+```bash
 uv run python evals/scripts/run_eval.py --case my_tests/single_case.json
+```
 
-# 精度のみ実行(高速)
+精度のみ実行(高速):
+
+```bash
 uv run python evals/scripts/run_eval.py --suite my_tests/my_suite.json --experiment accuracy
 ```
 
@@ -515,8 +525,8 @@ uv run python evals/scripts/run_eval.py --suite my_tests/my_suite.json --experim
 
 **CLI でツール設定を使用:**
 
-1. 上記のテストケースを`my_tests/compliance_with_kb.json`に保存(`YOUR_KB_ID`を実際のナレッジベース ID に置き換える)
-2. 実行:
+1. 上記のテストケースを`my_tests/compliance_with_kb.json`に保存します(`YOUR_KB_ID`を実際のナレッジベース ID に置き換えます)。
+2. 次のコマンドを実行します。
    ```bash
    cd review-item-processor
    uv run python evals/scripts/run_eval.py --case my_tests/compliance_with_kb.json

--- a/review-item-processor/evals/my_tests/README.md
+++ b/review-item-processor/evals/my_tests/README.md
@@ -10,7 +10,9 @@ cp template.json my_first_test.json
 ```
 
 ### 2. Add Your Document
+Create the `fixtures/` directory (it is not tracked in git) and copy your document into it:
 ```bash
+mkdir -p fixtures
 cp /path/to/your/document.pdf fixtures/
 ```
 
@@ -22,25 +24,26 @@ Open `my_first_test.json` and fill in:
 - `expected_output.result`: "pass" or "fail" (YOU decide ground truth)
 
 ### 4. Run Your Test
+Go to `review-item-processor/` and run the evaluation:
 ```bash
-cd ../..  # Go to review-item-processor/
+cd ../..
 uv run python evals/scripts/run_eval.py --suite my_tests/my_first_test.json
 ```
 
 ## Need Inspiration?
 
-Look at the working examples in `examples/` directory:
+Look at the working examples in the `../examples/` directory:
 - `floor_plan_hitl_suite.json` - 6 test cases with varying confidence
 - `fixtures/floor_plan_safety_reports.pdf` - Multi-page PDF example
 
 ## Directory Structure
 ```
 my_tests/
+├── README.md              ← This file
 ├── template.json          ← Copy this to start
 ├── your_suite.json        ← Your custom tests
-└── fixtures/
-    ├── your_document.pdf  ← Your test files
-    └── README.md          ← This file
+└── fixtures/              ← Created in step 2
+    └── your_document.pdf  ← Your test files
 ```
 
 ## Tips

--- a/review-item-processor/index.py
+++ b/review-item-processor/index.py
@@ -17,7 +17,6 @@ from s3_temp_utils import S3TempStorage
 # Environment variables
 DOCUMENT_BUCKET = os.environ.get("DOCUMENT_BUCKET", "")
 TEMP_BUCKET = os.environ.get("TEMP_BUCKET", "")
-BEDROCK_REGION = os.environ.get("BEDROCK_REGION", "us-west-2")
 
 
 @app.entrypoint
@@ -36,11 +35,27 @@ def handler(event, context):
         "languageName": "language name"
     }
     """
-    logger.info(f"[Strands MCP] Received event: {json.dumps(event)}")
-    
+    # 生の event 全体（toolConfiguration の MCP 秘密・headers/env を含みうる）を
+    # ログに出さない。相関に必要な非機微スカラのみを記録する
+    # （詳細な相関 ID は直後の info ログで出力）。
+    logger.info(
+        "[Strands MCP] Received event "
+        f"(reviewJobId={event.get('reviewJobId', 'N/A')}, "
+        f"reviewResultId={event.get('reviewResultId', 'N/A')}, "
+        f"checkId={event.get('checkId', 'N/A')}, "
+        f"documentPaths={len(event.get('documentPaths', []) or [])})"
+    )
+
     # Log session and trace information from context
+    # bedrock-agentcore 1.x では RequestContext.request_headers は「属性は常に
+    # 存在するが値は None になり得る」Optional フィールドのため、getattr の
+    # デフォルト値では None を防げない。`or {}` で None を空 dict に正規化する
+    # （0.1.0 は属性自体が無く getattr のデフォルトが効いていた）。
+    # In bedrock-agentcore 1.x, RequestContext.request_headers is an Optional
+    # field: the attribute always exists but may be None, so getattr's default
+    # alone no longer protects the .get() below. Normalize None with `or {}`.
     session_id = getattr(context, 'session_id', 'N/A')
-    request_headers = getattr(context, 'request_headers', {})
+    request_headers = getattr(context, 'request_headers', None) or {}
     trace_id = request_headers.get('X-Amzn-Trace-Id', 'N/A')
     
     logger.info(f"AgentCore Session ID: {session_id}")
@@ -50,7 +65,7 @@ def handler(event, context):
     logger.info(f"checkId: {event.get('checkId', 'N/A')}")
 
     # Check required environment variables
-    required_vars = ["DOCUMENT_BUCKET", "BEDROCK_REGION"]
+    required_vars = ["DOCUMENT_BUCKET"]
     missing_vars = [var for var in required_vars if not os.environ.get(var)]
     if missing_vars:
         logger.error(
@@ -82,13 +97,18 @@ def handler(event, context):
         # The agent.py will automatically detect file types and select the appropriate model
         # Extract tool configuration if available
         tool_configuration = event.get("toolConfiguration")
-        feedback_summary = event.get("feedbackSummary")
         model_id_override = event.get("modelId")
-        logger.debug(
-            f"[DEBUG LAMBDA] Tool configuration: {json.dumps(tool_configuration)}"
-        )
-        if feedback_summary:
-            logger.debug(f"[DEBUG LAMBDA] Feedback summary available for check")
+        # toolConfiguration には MCP 資格情報（headers/env）が含まれうるため、
+        # 値をシリアライズしない。有無とトップレベルキーのみを記録する。
+        if isinstance(tool_configuration, dict):
+            logger.debug(
+                f"[DEBUG LAMBDA] Tool configuration present; "
+                f"keys={sorted(tool_configuration.keys())}"
+            )
+        else:
+            logger.debug(
+                f"[DEBUG LAMBDA] Tool configuration present={tool_configuration is not None}"
+            )
         if model_id_override:
             logger.info(f"[DEBUG LAMBDA] Per-item model override: {model_id_override}")
 
@@ -100,7 +120,6 @@ def handler(event, context):
             language_name=language_name,
             model_id=model_id_override,
             toolConfiguration=tool_configuration,
-            feedback_summary=feedback_summary,
         )
 
         # Return results to Step Functions - handle both PDF and image results

--- a/review-item-processor/logger.py
+++ b/review-item-processor/logger.py
@@ -1,16 +1,43 @@
 import logging
+import os
+
+# ログレベルをハードコードの DEBUG 固定から環境変数 (LOG_LEVEL) 制御に変更する。
+# 既定は INFO なので、文書内容を含みうる logger.debug は本番で出力されない
+# （文書内容漏洩の防止）。詳細調査時のみ LOG_LEVEL=DEBUG を設定して
+# 一時的に debug 出力を有効化する運用を想定する。
+_DEFAULT_LOG_LEVEL = "INFO"
+
+
+def _resolve_log_level() -> int:
+    """環境変数 LOG_LEVEL からログレベル（int）を解決する。
+
+    未設定・不正値（解釈不能なレベル名）の場合は INFO にフォールバックする。
+    大文字小文字は無視する（例: "debug" / "DEBUG" のいずれも許容）。
+    """
+    name = os.environ.get("LOG_LEVEL", _DEFAULT_LOG_LEVEL).strip().upper()
+    level = logging.getLevelName(name)
+    # logging.getLevelName は既知レベル名なら int、未知名なら "Level <name>" の文字列を返す。
+    if isinstance(level, int):
+        return level
+    return logging.INFO
+
 
 # Global logger instance
 _logger = logging.getLogger(__name__)
-_logger.setLevel(logging.DEBUG)
+_logger.setLevel(_resolve_log_level())
+
 
 def set_logger(logger):
     global _logger
     _logger = logger
-    _logger.setLevel(logging.DEBUG)
+    # 差し替えられた logger にも DEBUG 固定ではなく
+    # 解決済みレベル（既定 INFO）を適用する。
+    _logger.setLevel(_resolve_log_level())
+
 
 class LoggerProxy:
     def __getattr__(self, name):
         return getattr(_logger, name)
+
 
 logger = LoggerProxy()

--- a/review-item-processor/model_config.py
+++ b/review-item-processor/model_config.py
@@ -21,8 +21,12 @@ class ModelConfig:
     
     model_id: str
     display_name: str
-    input_per_1k: float
-    output_per_1k: float
+    # Pricing is expressed per 1,000,000 (1M) tokens in USD, matching the
+    # Amazon Bedrock pricing page (e.g. Claude Sonnet = $3 / $15 per 1M tokens
+    # => input_per_1m=3.0, output_per_1m=15.0). Cost is computed as
+    # tokens / 1_000_000 * per_1m (see agent.py).
+    input_per_1m: float
+    output_per_1m: float
     supports_document_block: bool
     supports_citation: bool
     supports_caching: bool
@@ -72,8 +76,8 @@ _MODEL_REGISTRY = {
     "us.anthropic.claude-3-7-sonnet-20250219-v1:0": ModelConfig(
         model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
         display_name="Claude 3.7 Sonnet (US)",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -82,8 +86,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-3-7-sonnet-20250219-v1:0": ModelConfig(
         model_id="anthropic.claude-3-7-sonnet-20250219-v1:0",
         display_name="Claude 3.7 Sonnet",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -93,8 +97,8 @@ _MODEL_REGISTRY = {
     "global.anthropic.claude-sonnet-4-20250514-v1:0": ModelConfig(
         model_id="global.anthropic.claude-sonnet-4-20250514-v1:0",
         display_name="Claude 4 Sonnet (Global)",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -103,8 +107,8 @@ _MODEL_REGISTRY = {
     "us.anthropic.claude-sonnet-4-20250514-v1:0": ModelConfig(
         model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
         display_name="Claude 4 Sonnet (US)",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -113,8 +117,8 @@ _MODEL_REGISTRY = {
     "eu.anthropic.claude-sonnet-4-20250514-v1:0": ModelConfig(
         model_id="eu.anthropic.claude-sonnet-4-20250514-v1:0",
         display_name="Claude 4 Sonnet (EU)",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -123,8 +127,8 @@ _MODEL_REGISTRY = {
     "apac.anthropic.claude-sonnet-4-20250514-v1:0": ModelConfig(
         model_id="apac.anthropic.claude-sonnet-4-20250514-v1:0",
         display_name="Claude 4 Sonnet (APAC)",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -133,8 +137,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-sonnet-4-20250514-v1:0": ModelConfig(
         model_id="anthropic.claude-sonnet-4-20250514-v1:0",
         display_name="Claude 4 Sonnet",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -144,8 +148,8 @@ _MODEL_REGISTRY = {
     "global.anthropic.claude-sonnet-4-5-20250929-v1:0": ModelConfig(
         model_id="global.anthropic.claude-sonnet-4-5-20250929-v1:0",
         display_name="Claude 4.5 Sonnet (Global)",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -154,8 +158,8 @@ _MODEL_REGISTRY = {
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": ModelConfig(
         model_id="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         display_name="Claude 4.5 Sonnet (US)",
-        input_per_1k=0.0033,
-        output_per_1k=0.0165,
+        input_per_1m=3.3,
+        output_per_1m=16.5,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -164,8 +168,8 @@ _MODEL_REGISTRY = {
     "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": ModelConfig(
         model_id="eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
         display_name="Claude 4.5 Sonnet (EU)",
-        input_per_1k=0.0033,
-        output_per_1k=0.0165,
+        input_per_1m=3.3,
+        output_per_1m=16.5,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -174,8 +178,8 @@ _MODEL_REGISTRY = {
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": ModelConfig(
         model_id="jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
         display_name="Claude 4.5 Sonnet (JP)",
-        input_per_1k=0.0033,
-        output_per_1k=0.0165,
+        input_per_1m=3.3,
+        output_per_1m=16.5,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -184,8 +188,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-sonnet-4-5-20250929-v1:0": ModelConfig(
         model_id="anthropic.claude-sonnet-4-5-20250929-v1:0",
         display_name="Claude 4.5 Sonnet",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -195,8 +199,8 @@ _MODEL_REGISTRY = {
     "global.anthropic.claude-opus-4-5-20251101-v1:0": ModelConfig(
         model_id="global.anthropic.claude-opus-4-5-20251101-v1:0",
         display_name="Claude 4.5 Opus (Global)",
-        input_per_1k=0.005,
-        output_per_1k=0.025,
+        input_per_1m=5.0,
+        output_per_1m=25.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -206,8 +210,8 @@ _MODEL_REGISTRY = {
     "global.anthropic.claude-sonnet-4-6": ModelConfig(
         model_id="global.anthropic.claude-sonnet-4-6",
         display_name="Claude Sonnet 4.6 (Global)",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -216,8 +220,8 @@ _MODEL_REGISTRY = {
     "us.anthropic.claude-sonnet-4-6": ModelConfig(
         model_id="us.anthropic.claude-sonnet-4-6",
         display_name="Claude Sonnet 4.6 (US)",
-        input_per_1k=0.0033,
-        output_per_1k=0.0165,
+        input_per_1m=3.3,
+        output_per_1m=16.5,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -226,8 +230,8 @@ _MODEL_REGISTRY = {
     "eu.anthropic.claude-sonnet-4-6": ModelConfig(
         model_id="eu.anthropic.claude-sonnet-4-6",
         display_name="Claude Sonnet 4.6 (EU)",
-        input_per_1k=0.0033,
-        output_per_1k=0.0165,
+        input_per_1m=3.3,
+        output_per_1m=16.5,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -236,8 +240,8 @@ _MODEL_REGISTRY = {
     "jp.anthropic.claude-sonnet-4-6": ModelConfig(
         model_id="jp.anthropic.claude-sonnet-4-6",
         display_name="Claude Sonnet 4.6 (JP)",
-        input_per_1k=0.0033,
-        output_per_1k=0.0165,
+        input_per_1m=3.3,
+        output_per_1m=16.5,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -246,8 +250,8 @@ _MODEL_REGISTRY = {
     "au.anthropic.claude-sonnet-4-6": ModelConfig(
         model_id="au.anthropic.claude-sonnet-4-6",
         display_name="Claude Sonnet 4.6 (AU)",
-        input_per_1k=0.0033,
-        output_per_1k=0.0165,
+        input_per_1m=3.3,
+        output_per_1m=16.5,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -256,8 +260,48 @@ _MODEL_REGISTRY = {
     "anthropic.claude-sonnet-4-6": ModelConfig(
         model_id="anthropic.claude-sonnet-4-6",
         display_name="Claude Sonnet 4.6",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    # Claude Sonnet 5 (launched 2026-07-01, Active).
+    # Pricing: standard on-demand is $3 / $15 per 1M input/output tokens
+    # (=> input_per_1m=3.0 / output_per_1m=15.0), matching Sonnet 4.5/4.6. A
+    # promotional launch price of $2 / $10 per 1M is in effect through
+    # 2026-08-31; we record the standard rate here (cost figures are for
+    # display/estimation only).
+    # 価格は標準レート（プロモ期間 〜2026-08-31 は $2/$10）。請求実績で要確認 (verify against billing).
+    # Regional CRIS entries (us.) use +10% per the existing convention.
+    # Capabilities follow the Claude 4.x/Sonnet family: document block + Citations
+    # API + prompt caching.
+    "global.anthropic.claude-sonnet-5": ModelConfig(
+        model_id="global.anthropic.claude-sonnet-5",
+        display_name="Claude Sonnet 5 (Global)",
+        input_per_1m=3.0,   # standard rate; promo $2/1M until 2026-08-31 / 請求実績で要確認
+        output_per_1m=15.0,  # standard rate; promo $10/1M until 2026-08-31 / 請求実績で要確認
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "us.anthropic.claude-sonnet-5": ModelConfig(
+        model_id="us.anthropic.claude-sonnet-5",
+        display_name="Claude Sonnet 5 (US)",
+        input_per_1m=3.3,   # +10% CRIS convention; standard rate / 請求実績で要確認
+        output_per_1m=16.5,  # +10% CRIS convention; standard rate / 請求実績で要確認
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "anthropic.claude-sonnet-5": ModelConfig(
+        model_id="anthropic.claude-sonnet-5",
+        display_name="Claude Sonnet 5",
+        input_per_1m=3.0,   # standard rate; promo $2/1M until 2026-08-31 / 請求実績で要確認
+        output_per_1m=15.0,  # standard rate; promo $10/1M until 2026-08-31 / 請求実績で要確認
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -267,8 +311,190 @@ _MODEL_REGISTRY = {
     "global.anthropic.claude-opus-4-6-v1": ModelConfig(
         model_id="global.anthropic.claude-opus-4-6-v1",
         display_name="Claude Opus 4.6 (Global)",
-        input_per_1k=0.005,
-        output_per_1k=0.025,
+        input_per_1m=5.0,
+        output_per_1m=25.0,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+    # Claude Opus 4.7
+    "global.anthropic.claude-opus-4-7": ModelConfig(
+        model_id="global.anthropic.claude-opus-4-7",
+        display_name="Claude Opus 4.7 (Global)",
+        input_per_1m=5.0,
+        output_per_1m=25.0,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "us.anthropic.claude-opus-4-7": ModelConfig(
+        model_id="us.anthropic.claude-opus-4-7",
+        display_name="Claude Opus 4.7 (US)",
+        input_per_1m=5.0,
+        output_per_1m=25.0,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "eu.anthropic.claude-opus-4-7": ModelConfig(
+        model_id="eu.anthropic.claude-opus-4-7",
+        display_name="Claude Opus 4.7 (EU)",
+        input_per_1m=5.0,
+        output_per_1m=25.0,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "jp.anthropic.claude-opus-4-7": ModelConfig(
+        model_id="jp.anthropic.claude-opus-4-7",
+        display_name="Claude Opus 4.7 (JP)",
+        input_per_1m=5.0,
+        output_per_1m=25.0,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "au.anthropic.claude-opus-4-7": ModelConfig(
+        model_id="au.anthropic.claude-opus-4-7",
+        display_name="Claude Opus 4.7 (AU)",
+        input_per_1m=5.0,
+        output_per_1m=25.0,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    # Claude Opus 4.8
+    # Pricing is provisional: same as Opus 4.6/4.7 ($5 / $25 per 1M tokens
+    # => input_per_1m=5.0 / output_per_1m=25.0).
+    # 請求実績で要確認 (provisional, verify against actual billing).
+    "global.anthropic.claude-opus-4-8": ModelConfig(
+        model_id="global.anthropic.claude-opus-4-8",
+        display_name="Claude Opus 4.8 (Global)",
+        input_per_1m=5.0,   # provisional, verify against actual billing / 請求実績で要確認
+        output_per_1m=25.0,  # provisional, verify against actual billing / 請求実績で要確認
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "us.anthropic.claude-opus-4-8": ModelConfig(
+        model_id="us.anthropic.claude-opus-4-8",
+        display_name="Claude Opus 4.8 (US)",
+        input_per_1m=5.0,   # provisional, verify against actual billing / 請求実績で要確認
+        output_per_1m=25.0,  # provisional, verify against actual billing / 請求実績で要確認
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "eu.anthropic.claude-opus-4-8": ModelConfig(
+        model_id="eu.anthropic.claude-opus-4-8",
+        display_name="Claude Opus 4.8 (EU)",
+        input_per_1m=5.0,   # provisional, verify against actual billing / 請求実績で要確認
+        output_per_1m=25.0,  # provisional, verify against actual billing / 請求実績で要確認
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "jp.anthropic.claude-opus-4-8": ModelConfig(
+        model_id="jp.anthropic.claude-opus-4-8",
+        display_name="Claude Opus 4.8 (JP)",
+        input_per_1m=5.0,   # provisional, verify against actual billing / 請求実績で要確認
+        output_per_1m=25.0,  # provisional, verify against actual billing / 請求実績で要確認
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "au.anthropic.claude-opus-4-8": ModelConfig(
+        model_id="au.anthropic.claude-opus-4-8",
+        display_name="Claude Opus 4.8 (AU)",
+        input_per_1m=5.0,   # provisional, verify against actual billing / 請求実績で要確認
+        output_per_1m=25.0,  # provisional, verify against actual billing / 請求実績で要確認
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "anthropic.claude-opus-4-8": ModelConfig(
+        model_id="anthropic.claude-opus-4-8",
+        display_name="Claude Opus 4.8",
+        input_per_1m=5.0,   # provisional, verify against actual billing / 請求実績で要確認
+        output_per_1m=25.0,  # provisional, verify against actual billing / 請求実績で要確認
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+    # Claude Haiku 4.5
+    # Lightweight current-gen Claude (launched 2025-10-16, Active). Model IDs per the
+    # AWS Bedrock model card (base + us/eu/jp/au geo + global inference profiles).
+    # Pricing follows Anthropic public pricing ($1 / $5 per 1M tokens =>
+    # input_per_1m=1.0 / output_per_1m=5.0); regional CRIS entries use +10% per
+    # the existing convention.
+    # 価格は暫定 (provisional)、請求実績で要確認.
+    # Capabilities follow the Claude 4.x family: document block + Citations API + prompt
+    # caching (prompt caching is confirmed supported on the model card).
+    "global.anthropic.claude-haiku-4-5-20251001-v1:0": ModelConfig(
+        model_id="global.anthropic.claude-haiku-4-5-20251001-v1:0",
+        display_name="Claude Haiku 4.5 (Global)",
+        input_per_1m=1.0,
+        output_per_1m=5.0,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0": ModelConfig(
+        model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        display_name="Claude Haiku 4.5 (US)",
+        input_per_1m=1.1,
+        output_per_1m=5.5,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "eu.anthropic.claude-haiku-4-5-20251001-v1:0": ModelConfig(
+        model_id="eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+        display_name="Claude Haiku 4.5 (EU)",
+        input_per_1m=1.1,
+        output_per_1m=5.5,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "jp.anthropic.claude-haiku-4-5-20251001-v1:0": ModelConfig(
+        model_id="jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+        display_name="Claude Haiku 4.5 (JP)",
+        input_per_1m=1.1,
+        output_per_1m=5.5,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "au.anthropic.claude-haiku-4-5-20251001-v1:0": ModelConfig(
+        model_id="au.anthropic.claude-haiku-4-5-20251001-v1:0",
+        display_name="Claude Haiku 4.5 (AU)",
+        input_per_1m=1.1,
+        output_per_1m=5.5,
+        supports_document_block=True,
+        supports_citation=True,
+        supports_caching=True,
+    ),
+
+    "anthropic.claude-haiku-4-5-20251001-v1:0": ModelConfig(
+        model_id="anthropic.claude-haiku-4-5-20251001-v1:0",
+        display_name="Claude Haiku 4.5",
+        input_per_1m=1.0,
+        output_per_1m=5.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -278,8 +504,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-opus-4-20250514-v1:0": ModelConfig(
         model_id="anthropic.claude-opus-4-20250514-v1:0",
         display_name="Claude 4 Opus",
-        input_per_1k=0.015,
-        output_per_1k=0.075,
+        input_per_1m=15.0,
+        output_per_1m=75.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -289,8 +515,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-3-5-sonnet-20241022-v2:0": ModelConfig(
         model_id="anthropic.claude-3-5-sonnet-20241022-v2:0",
         display_name="Claude 3.5 Sonnet v2",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=True,
@@ -299,8 +525,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-3-5-sonnet-20240620-v1:0": ModelConfig(
         model_id="anthropic.claude-3-5-sonnet-20240620-v1:0",
         display_name="Claude 3.5 Sonnet v1",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=False,
         supports_caching=True,
@@ -310,8 +536,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-3-5-haiku-20241022-v1:0": ModelConfig(
         model_id="anthropic.claude-3-5-haiku-20241022-v1:0",
         display_name="Claude 3.5 Haiku",
-        input_per_1k=0.001,
-        output_per_1k=0.005,
+        input_per_1m=1.0,
+        output_per_1m=5.0,
         supports_document_block=True,
         supports_citation=False,
         supports_caching=True,
@@ -321,8 +547,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-3-opus-20240229-v1:0": ModelConfig(
         model_id="anthropic.claude-3-opus-20240229-v1:0",
         display_name="Claude 3 Opus",
-        input_per_1k=0.015,
-        output_per_1k=0.075,
+        input_per_1m=15.0,
+        output_per_1m=75.0,
         supports_document_block=True,
         supports_citation=False,
         supports_caching=True,
@@ -332,8 +558,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-3-sonnet-20240229-v1:0": ModelConfig(
         model_id="anthropic.claude-3-sonnet-20240229-v1:0",
         display_name="Claude 3 Sonnet",
-        input_per_1k=0.003,
-        output_per_1k=0.015,
+        input_per_1m=3.0,
+        output_per_1m=15.0,
         supports_document_block=True,
         supports_citation=False,
         supports_caching=True,
@@ -343,8 +569,8 @@ _MODEL_REGISTRY = {
     "anthropic.claude-3-haiku-20240307-v1:0": ModelConfig(
         model_id="anthropic.claude-3-haiku-20240307-v1:0",
         display_name="Claude 3 Haiku",
-        input_per_1k=0.00025,
-        output_per_1k=0.00125,
+        input_per_1m=0.25,
+        output_per_1m=1.25,
         supports_document_block=True,
         supports_citation=False,
         supports_caching=True,
@@ -354,8 +580,8 @@ _MODEL_REGISTRY = {
     "us.amazon.nova-premier-v1:0": ModelConfig(
         model_id="us.amazon.nova-premier-v1:0",
         display_name="Amazon Nova Premier",
-        input_per_1k=0.0025,
-        output_per_1k=0.0125,
+        input_per_1m=2.5,
+        output_per_1m=12.5,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=False,
@@ -364,8 +590,8 @@ _MODEL_REGISTRY = {
     "amazon.nova-premier-v1:0": ModelConfig(
         model_id="amazon.nova-premier-v1:0",
         display_name="Amazon Nova Premier",
-        input_per_1k=0.0025,
-        output_per_1k=0.0125,
+        input_per_1m=2.5,
+        output_per_1m=12.5,
         supports_document_block=True,
         supports_citation=True,
         supports_caching=False,
@@ -375,8 +601,8 @@ _MODEL_REGISTRY = {
     "us.amazon.nova-2-omni-v1:0": ModelConfig(
         model_id="us.amazon.nova-2-omni-v1:0",
         display_name="Amazon Nova 2 Omni",
-        input_per_1k=0.0003,
-        output_per_1k=0.0025,
+        input_per_1m=0.3,
+        output_per_1m=2.5,
         supports_document_block=True,
         supports_citation=False,
         supports_caching=False,
@@ -386,8 +612,8 @@ _MODEL_REGISTRY = {
     "amazon.nova-2-omni-v1:0": ModelConfig(
         model_id="amazon.nova-2-omni-v1:0",
         display_name="Amazon Nova 2 Omni",
-        input_per_1k=0.0003,
-        output_per_1k=0.0025,
+        input_per_1m=0.3,
+        output_per_1m=2.5,
         supports_document_block=True,
         supports_citation=False,
         supports_caching=False,
@@ -398,8 +624,8 @@ _MODEL_REGISTRY = {
 _DEFAULT_CONFIG = ModelConfig(
     model_id="unknown",
     display_name="Unknown Model",
-    input_per_1k=0.0,
-    output_per_1k=0.0,
+    input_per_1m=0.0,
+    output_per_1m=0.0,
     supports_document_block=False,
     supports_citation=False,
     supports_caching=False,

--- a/review-item-processor/pyproject.toml
+++ b/review-item-processor/pyproject.toml
@@ -3,9 +3,31 @@ name = "review-item-processor"
 version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
-    "strands-agents>=1.30.0",
-    "strands-agents-tools[agent_core_code_interpreter]>=0.2.14",
-    "bedrock-agentcore==0.1.0",
+    # 手動配置 cachePoint を尊重する挙動（_honor_placed_cache_point）は
+    # strands-agents 1.52.0 で導入された。agent.py は文書ブロックと項目別
+    # プロンプトの間に明示 cachePoint を置いて項目間キャッシュ共有を実現して
+    # おり、1.30〜1.51 の auto は手動配置をストリップして共有を静かに失わせる
+    # ため、下限を 1.52.0 に固定する。
+    # The honor-placed-cachePoint behavior (_honor_placed_cache_point) landed
+    # in strands-agents 1.52.0. agent.py places an explicit cachePoint between
+    # the document blocks and the per-item prompt to share the document prefix
+    # across review items; auto mode in 1.30-1.51 strips manually placed
+    # points and silently loses that sharing, so the floor is pinned at 1.52.0.
+    "strands-agents>=1.52.0",
+    # agent_core_code_interpreter extra は bedrock-agentcore(<1.2.0) を引き込む
+    # だけで他の依存を追加しない。本プロジェクトは strands-agents-tools 側の
+    # code interpreter ツールを使わず（独自の tools/code_interpreter.py が
+    # bedrock_agentcore.tools.code_interpreter_client.code_session を直接使用）、
+    # bedrock-agentcore は下で直接ピン留めしているため、extra の古いバージョン
+    # 制約が SDK 更新を妨げないよう extra を外す。
+    # The agent_core_code_interpreter extra only pulls in bedrock-agentcore
+    # (<1.2.0) and nothing else. This project does not use the
+    # strands-agents-tools code interpreter tool (our own
+    # tools/code_interpreter.py calls the SDK's code_session directly), and
+    # bedrock-agentcore is pinned directly below, so the extra is dropped to
+    # keep its stale version cap from blocking SDK upgrades.
+    "strands-agents-tools>=0.2.14",
+    "bedrock-agentcore==1.18.0",
     "pillow>=11.2.1",
     "boto3>=1.40.22",
     "anyio>=4.0.0",

--- a/review-item-processor/s3_temp_utils.py
+++ b/review-item-processor/s3_temp_utils.py
@@ -47,11 +47,19 @@ class S3TempStorage:
         S3参照から実データを復元
         """
         if self._is_s3_temp_ref(input_data):
+            # 参照内の bucket を信頼せず、アプリ構成で定めたバケット
+            # （self.bucket_name）に限定する。forge された参照が別バケットを
+            # 指す場合は拒否（フェイルクローズ）。
+            if input_data["bucket"] != self.bucket_name:
+                raise ValueError(
+                    f"[S3Temp] Refusing to resolve reference with untrusted "
+                    f"bucket: {input_data['bucket']}"
+                )
             print(f"[S3Temp] Resolving data from: {input_data['key']}")
-            
-            # S3から実データを取得
+
+            # S3から実データを取得（bucket は構成値に固定）
             response = self.s3_client.get_object(
-                Bucket=input_data["bucket"], Key=input_data["key"]
+                Bucket=self.bucket_name, Key=input_data["key"]
             )
             
             body = response["Body"].read().decode("utf-8")
@@ -80,7 +88,8 @@ class S3TempStorage:
     def _cleanup(self, ref: dict) -> None:
         """S3の一時データを削除"""
         try:
-            self.s3_client.delete_object(Bucket=ref["bucket"], Key=ref["key"])
+            # bucket は構成値に固定（参照内 bucket を信頼しない）。
+            self.s3_client.delete_object(Bucket=self.bucket_name, Key=ref["key"])
             print(f"[S3Temp] Cleaned up: {ref['key']}")
         except Exception as e:
             print(f"[S3Temp] Failed to cleanup {ref['key']}: {str(e)}")

--- a/review-item-processor/test_file_access.py
+++ b/review-item-processor/test_file_access.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+束縛版 file_read / image_reader
+（create_bounded_file_read_tool / create_bounded_image_reader_tool）の LFI 対策を
+検証するユニットテスト。
+
+許可ディレクトリ配下のファイルは読めるが、/etc/passwd・/proc/self/environ・トラバーサル・
+グロブ・~ 展開・prefix confusion・symlink escape・許可外 mode は全て拒否されることを担保する。
+AWS リソース非依存・ネットワーク非依存（tmp_path fixture のみ使用）。
+"""
+import os
+
+import pytest
+
+from tools.file_access import (
+    create_bounded_file_read_tool,
+    create_bounded_image_reader_tool,
+)
+
+
+def _make_tool(tmp_path):
+    job_dir = tmp_path / "jobX"
+    job_dir.mkdir()
+    target = job_dir / "doc.txt"
+    target.write_text("HELLO_DOCUMENT_CONTENT")
+    tool = create_bounded_file_read_tool([str(job_dir)])
+    return tool, job_dir, target
+
+
+def test_reads_file_within_allowed_dir(tmp_path):
+    tool, _job_dir, target = _make_tool(tmp_path)
+    result = tool(path=str(target), mode="view")
+    assert result["status"] == "success"
+    # 内容が返ってくること。
+    text = "".join(
+        block.get("text", "") for block in result["content"] if isinstance(block, dict)
+    )
+    assert "HELLO_DOCUMENT_CONTENT" in text
+
+
+def test_rejects_etc_passwd(tmp_path):
+    tool, _job_dir, _target = _make_tool(tmp_path)
+    result = tool(path="/etc/passwd", mode="view")
+    assert result["status"] == "error"
+    # 汎用文言で許可外パスを含めない（情報漏洩防止）。
+    assert "/etc/passwd" not in str(result)
+
+
+def test_rejects_proc_self_environ(tmp_path):
+    tool, _job_dir, _target = _make_tool(tmp_path)
+    result = tool(path="/proc/self/environ", mode="view")
+    assert result["status"] == "error"
+
+
+def test_rejects_parent_traversal(tmp_path):
+    tool, job_dir, _target = _make_tool(tmp_path)
+    # job_dir/../ で許可外へ抜けようとする。
+    result = tool(path=os.path.join(str(job_dir), "..", "secret.txt"), mode="view")
+    assert result["status"] == "error"
+
+
+def test_rejects_glob_metacharacters(tmp_path):
+    tool, job_dir, _target = _make_tool(tmp_path)
+    result = tool(path=os.path.join(str(job_dir), "*.txt"), mode="view")
+    assert result["status"] == "error"
+
+
+def test_rejects_tilde_expansion(tmp_path):
+    tool, _job_dir, _target = _make_tool(tmp_path)
+    result = tool(path="~/.aws/credentials", mode="view")
+    assert result["status"] == "error"
+
+
+def test_rejects_prefix_confusion(tmp_path):
+    # /tmp/jobX に束縛されている状態で /tmp/jobXY を読もうとしても拒否される
+    # （prefix 文字列一致の罠を回避できていることの確認）。
+    job_dir = tmp_path / "jobX"
+    job_dir.mkdir()
+    sibling = tmp_path / "jobXY"
+    sibling.mkdir()
+    secret = sibling / "secret.txt"
+    secret.write_text("SHOULD_NOT_BE_READABLE")
+
+    tool = create_bounded_file_read_tool([str(job_dir)])
+    result = tool(path=str(secret), mode="view")
+    assert result["status"] == "error"
+    assert "SHOULD_NOT_BE_READABLE" not in str(result)
+
+
+def test_rejects_symlink_escape(tmp_path):
+    # 許可ディレクトリ内に許可外ファイルを指す symlink を置いても、realpath 解決で拒否される。
+    job_dir = tmp_path / "jobX"
+    job_dir.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("OUTSIDE_SECRET")
+    link = job_dir / "link.txt"
+    link.symlink_to(outside)
+
+    tool = create_bounded_file_read_tool([str(job_dir)])
+    result = tool(path=str(link), mode="view")
+    assert result["status"] == "error"
+    assert "OUTSIDE_SECRET" not in str(result)
+
+
+def test_rejects_disallowed_mode_document(tmp_path):
+    tool, _job_dir, target = _make_tool(tmp_path)
+    # 許可内パスでも document mode は拒否される。
+    result = tool(path=str(target), mode="document")
+    assert result["status"] == "error"
+
+
+def test_rejects_disallowed_mode_diff(tmp_path):
+    tool, _job_dir, target = _make_tool(tmp_path)
+    result = tool(path=str(target), mode="diff")
+    assert result["status"] == "error"
+
+
+def test_rejects_disallowed_mode_find(tmp_path):
+    tool, job_dir, _target = _make_tool(tmp_path)
+    result = tool(path=str(job_dir), mode="find")
+    assert result["status"] == "error"
+
+
+def test_tool_name_is_file_read(tmp_path):
+    # プロンプトが参照する "file_read" の名前が維持されていること（回帰防止）。
+    tool, _job_dir, _target = _make_tool(tmp_path)
+    assert tool.tool_name == "file_read"
+
+
+# ---------------------------------------------------------------------------
+# 束縛版 image_reader のユニットテスト。
+# 素の image_reader は image_path を expanduser で ~ 展開し任意パスの画像を読むため LFI。
+# file_read 束縛と同型に allowed_dirs 配下のみ許可されることを担保する。
+# ---------------------------------------------------------------------------
+
+
+def _write_png(path) -> None:
+    """PIL で最小の有効な PNG を書き出す（image_reader が format 判定できるように）。"""
+    from PIL import Image
+
+    Image.new("RGB", (2, 2), color=(123, 45, 67)).save(str(path), format="PNG")
+
+
+def _make_image_tool(tmp_path):
+    job_dir = tmp_path / "jobX"
+    job_dir.mkdir()
+    image = job_dir / "photo.png"
+    _write_png(image)
+    tool = create_bounded_image_reader_tool([str(job_dir)])
+    return tool, job_dir, image
+
+
+def test_image_reads_within_allowed_dir(tmp_path):
+    tool, _job_dir, image = _make_image_tool(tmp_path)
+    result = tool(image_path=str(image))
+    assert result["status"] == "success"
+    # 画像バイトが image ブロックで返ってくること。
+    assert any(
+        isinstance(block, dict) and "image" in block
+        for block in result["content"]
+    )
+
+
+def test_image_rejects_outside_allowed_dir(tmp_path):
+    # 許可ディレクトリ外の画像（兄弟ディレクトリ）は拒否される。
+    job_dir = tmp_path / "jobX"
+    job_dir.mkdir()
+    outside_dir = tmp_path / "secret"
+    outside_dir.mkdir()
+    outside_image = outside_dir / "leak.png"
+    _write_png(outside_image)
+
+    tool = create_bounded_image_reader_tool([str(job_dir)])
+    result = tool(image_path=str(outside_image))
+    assert result["status"] == "error"
+    assert str(outside_image) not in str(result)
+
+
+def test_image_rejects_parent_traversal(tmp_path):
+    tool, job_dir, _image = _make_image_tool(tmp_path)
+    result = tool(
+        image_path=os.path.join(str(job_dir), "..", "secret.png")
+    )
+    assert result["status"] == "error"
+
+
+def test_image_rejects_tilde_expansion(tmp_path):
+    tool, _job_dir, _image = _make_image_tool(tmp_path)
+    # 素の image_reader は ~ を expanduser で展開してしまうため、束縛版で遮断する。
+    result = tool(image_path="~/.aws/credentials")
+    assert result["status"] == "error"
+
+
+def test_image_rejects_glob_metacharacters(tmp_path):
+    tool, job_dir, _image = _make_image_tool(tmp_path)
+    result = tool(image_path=os.path.join(str(job_dir), "*.png"))
+    assert result["status"] == "error"
+
+
+def test_image_rejects_etc_path(tmp_path):
+    tool, _job_dir, _image = _make_image_tool(tmp_path)
+    # 許可外の絶対パス（/etc/...）は拒否される（汎用文言・パス非開示）。
+    result = tool(image_path="/etc/hosts")
+    assert result["status"] == "error"
+    assert "/etc/hosts" not in str(result)
+
+
+def test_image_rejects_prefix_confusion(tmp_path):
+    # /tmp/jobX 束縛で /tmp/jobXY を読もうとしても拒否される（prefix 文字列一致の罠回避）。
+    job_dir = tmp_path / "jobX"
+    job_dir.mkdir()
+    sibling = tmp_path / "jobXY"
+    sibling.mkdir()
+    secret = sibling / "secret.png"
+    _write_png(secret)
+
+    tool = create_bounded_image_reader_tool([str(job_dir)])
+    result = tool(image_path=str(secret))
+    assert result["status"] == "error"
+
+
+def test_image_rejects_symlink_escape(tmp_path):
+    # 許可ディレクトリ内に許可外画像を指す symlink を置いても realpath 解決で拒否される。
+    job_dir = tmp_path / "jobX"
+    job_dir.mkdir()
+    outside = tmp_path / "outside.png"
+    _write_png(outside)
+    link = job_dir / "link.png"
+    link.symlink_to(outside)
+
+    tool = create_bounded_image_reader_tool([str(job_dir)])
+    result = tool(image_path=str(link))
+    assert result["status"] == "error"
+
+
+def test_image_rejects_empty_path(tmp_path):
+    tool, _job_dir, _image = _make_image_tool(tmp_path)
+    result = tool(image_path="")
+    assert result["status"] == "error"
+
+
+def test_image_tool_name_is_image_reader(tmp_path):
+    # プロンプトが参照する "image_reader" の名前が維持されていること（回帰防止）。
+    tool, _job_dir, _image = _make_image_tool(tmp_path)
+    assert tool.tool_name == "image_reader"
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/review-item-processor/test_logger.py
+++ b/review-item-processor/test_logger.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+logger のログレベルが DEBUG ハードコードから
+環境変数 LOG_LEVEL 制御（既定 INFO）に変わったことを検証するユニットテスト。
+
+文書内容を含みうる logger.debug が本番（既定 INFO）で出力されないことが目的であり、
+ここでは「レベル解決ロジック」と「set_logger が解決レベルを適用すること」を担保する。
+AWS リソース非依存・ネットワーク非依存。
+"""
+import logging
+
+import pytest
+
+from logger import _resolve_log_level, set_logger
+
+
+def test_resolve_log_level_default_is_info(monkeypatch):
+    # 未設定なら INFO（debug は出力されない）。
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    assert _resolve_log_level() == logging.INFO
+
+
+def test_resolve_log_level_debug(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    assert _resolve_log_level() == logging.DEBUG
+
+
+def test_resolve_log_level_lowercase_debug(monkeypatch):
+    # 大文字小文字は無視する。
+    monkeypatch.setenv("LOG_LEVEL", "debug")
+    assert _resolve_log_level() == logging.DEBUG
+
+
+def test_resolve_log_level_with_whitespace(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "  warning  ")
+    assert _resolve_log_level() == logging.WARNING
+
+
+def test_resolve_log_level_invalid_falls_back_to_info(monkeypatch):
+    # 解釈不能な値は INFO にフォールバック（フェイルセーフ: debug を漏らさない）。
+    monkeypatch.setenv("LOG_LEVEL", "NOPE")
+    assert _resolve_log_level() == logging.INFO
+
+
+def test_resolve_log_level_empty_falls_back_to_info(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "")
+    assert _resolve_log_level() == logging.INFO
+
+
+def test_set_logger_applies_resolved_level_default(monkeypatch):
+    # 既定（LOG_LEVEL 未設定）では差し替え logger に INFO が適用される。
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    custom = logging.getLogger("test_set_logger_default")
+    custom.setLevel(logging.DEBUG)  # わざと DEBUG にしておく
+    set_logger(custom)
+    assert custom.level == logging.INFO
+
+
+def test_set_logger_applies_resolved_level_debug(monkeypatch):
+    # LOG_LEVEL=DEBUG なら差し替え logger に DEBUG が適用される。
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    custom = logging.getLogger("test_set_logger_debug")
+    custom.setLevel(logging.WARNING)
+    set_logger(custom)
+    assert custom.level == logging.DEBUG
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/review-item-processor/test_mcp_tool_env.py
+++ b/review-item-processor/test_mcp_tool_env.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+mcp_tool._build_stdio_env の純粋ユニットテスト。
+stdio MCP 子プロセスへ渡す env が「SDK 既定 env + UV_CONSTRAINT の加算のみ」で
+あることを固定する（os.environ の AWS 資格情報等が混入しないことの担保を兼ねる）。
+UV_CONSTRAINT が uvx の依存解決に mcp<2 を適用できないと、上限を宣言しない
+MCP サーバ (mcp-server-fetch 等) が mcp 2.0.0 (2026-07-28 公開・破壊的変更) を
+解決して import 時に即死し、"MCP error -32000: Connection closed" になる。
+AWS リソース非依存・ネットワーク非依存。
+"""
+import os
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+from mcp.client.stdio import get_default_environment
+
+
+def test_env_is_default_plus_constraint_only(tmp_path, monkeypatch):
+    """制約ファイルがあるとき: SDK 既定 env + UV_CONSTRAINT だけを返す。"""
+    constraints = tmp_path / "mcp-uv-constraints.txt"
+    constraints.write_text("mcp<2\n")
+    assert not any(ch.isspace() for ch in str(constraints)), (
+        "前提: pytest の tmp_path は空白を含まない"
+    )
+    monkeypatch.setattr(mcp_tool, "_UV_CONSTRAINTS_FILE", constraints)
+    # os.environ 由来の秘密が混入しないことを、目印を置いて確認する。
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "must-not-leak")
+
+    env = mcp_tool._build_stdio_env()
+
+    assert env is not None
+    assert env["UV_CONSTRAINT"] == str(constraints)
+    assert "AWS_SECRET_ACCESS_KEY" not in env
+    # UV_CONSTRAINT 以外は SDK 既定 env と完全一致（勝手なキーを足さない）。
+    without_constraint = {k: v for k, v in env.items() if k != "UV_CONSTRAINT"}
+    assert without_constraint == get_default_environment()
+
+
+def test_env_falls_back_to_none_when_file_missing(tmp_path, monkeypatch):
+    """制約ファイルが無い環境（ローカル実行等）では None = SDK 既定に委ねる。"""
+    monkeypatch.setattr(
+        mcp_tool, "_UV_CONSTRAINTS_FILE", tmp_path / "does-not-exist.txt"
+    )
+    assert mcp_tool._build_stdio_env() is None
+
+
+def test_env_falls_back_when_path_contains_whitespace(tmp_path, monkeypatch):
+    """uv は UV_CONSTRAINT を空白区切りの複数ファイルとして解釈するため、
+    空白を含むパスでは制約なし（None）へフォールバックする。"""
+    spaced_dir = tmp_path / "dir with space"
+    spaced_dir.mkdir()
+    constraints = spaced_dir / "mcp-uv-constraints.txt"
+    constraints.write_text("mcp<2\n")
+    monkeypatch.setattr(mcp_tool, "_UV_CONSTRAINTS_FILE", constraints)
+    assert mcp_tool._build_stdio_env() is None
+
+
+def test_repo_constraints_file_pins_mcp_below_2():
+    """リポジトリ同梱の制約ファイルが存在し mcp<2 を含む（Dockerfile の COPY 元）。"""
+    repo_file = mcp_tool._UV_CONSTRAINTS_FILE
+    assert repo_file.name == "mcp-uv-constraints.txt"
+    assert repo_file.is_file(), f"missing: {repo_file}"
+    lines = [
+        line.strip()
+        for line in repo_file.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    assert lines == ["mcp<2"]

--- a/review-item-processor/test_mcp_validation.py
+++ b/review-item-processor/test_mcp_validation.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+mcp_validation の SSRF IP 判定（_is_blocked_ip）の純粋ユニットテスト。
+
+Python の SSRF 検証が CGNAT(100.64.0.0/10) を素通りしていた回帰を防ぐ。
+TS 実装（mcp-validation.ts の isBlockedIpv4Octets）と網羅性を一致させることを
+検証する。AWS リソース非依存・ネットワーク非依存。
+"""
+import pytest
+
+import socket
+from urllib.parse import urlparse
+
+from tools.mcp_validation import (
+    _SHELL_METACHAR_RE,
+    _is_blocked_ip,
+    _mask_url_secrets,
+    assert_safe_mcp_args,
+    mask_mcp_server_config,
+    resolve_and_validate_mcp_url,
+    sanitize_mcp_env,
+    validate_stdio_config,
+)
+
+
+@pytest.mark.parametrize(
+    "ip,expected_blocked",
+    [
+        # CGNAT 100.64.0.0/10（RFC 6598）— 本修正の対象
+        ("100.64.0.1", True),
+        ("100.100.100.100", True),
+        ("100.127.255.254", True),
+        # CGNAT の境界外（パブリック）は許可
+        ("100.63.255.255", False),
+        ("100.128.0.1", False),
+        # 既存のブロック対象（回帰確認）
+        ("169.254.169.254", True),  # IMDS link-local
+        ("127.0.0.1", True),  # loopback
+        ("10.0.0.5", True),  # private
+        ("172.16.0.1", True),  # private
+        ("192.168.1.1", True),  # private
+        ("0.0.0.0", True),  # unspecified
+        # IPv4-mapped IPv6 経由の CGNAT / IMDS（バイパス対策）
+        ("::ffff:100.64.0.1", True),
+        ("::ffff:169.254.169.254", True),
+        # パブリックは許可
+        ("8.8.8.8", False),
+        ("1.1.1.1", False),
+        # IP として解釈不能はフェイルクローズ（ブロック）
+        ("not-an-ip", True),
+    ],
+)
+def test_is_blocked_ip(ip, expected_blocked):
+    assert _is_blocked_ip(ip) is expected_blocked
+
+
+# TS 側 SHELL_METACHAR_RE に NULL バイトが混入してスペースを検出できていなかった
+# 回帰の、Python ミラーとの一致を担保する。
+# Python の _SHELL_METACHAR_RE はスペース(0x20)を含み NULL(0x00)は含まない正が保たれている。
+def test_shell_metachar_re_matches_space_not_null():
+    assert _SHELL_METACHAR_RE.search(" ") is not None
+    assert _SHELL_METACHAR_RE.search("\x00") is None
+
+
+def test_assert_safe_mcp_args_rejects_space():
+    with pytest.raises(ValueError):
+        assert_safe_mcp_args(["foo bar"])
+    with pytest.raises(ValueError):
+        assert_safe_mcp_args(["--config", "a b c"])
+
+
+def test_assert_safe_mcp_args_allows_normal_args():
+    # スペースを含まない正常な args は通過する（回帰確認）
+    assert_safe_mcp_args(["--directory", "/tmp/x", "mcp-server-fetch"])
+    assert_safe_mcp_args([])
+
+
+# パッケージレジストリ/インデックス上書き系の env を拒否する。
+# TS 側 (mcp-validation.env.test.ts) と同一キー集合で同期させること。
+_REGISTRY_OVERRIDE_KEYS = [
+    # uv
+    "UV_INDEX_URL",
+    "UV_DEFAULT_INDEX",
+    "UV_INDEX",
+    "UV_EXTRA_INDEX_URL",
+    "UV_FIND_LINKS",
+    "UV_PYTHON",
+    "UV_CONFIG_FILE",
+    "UV_NATIVE_TLS",
+    "UV_INSECURE_HOST",
+    "UV_INDEX_FOO_USERNAME",
+    # pip
+    "PIP_INDEX_URL",
+    "PIP_EXTRA_INDEX_URL",
+    # npm
+    "NPM_CONFIG_REGISTRY",
+    "NPM_CONFIG_USERCONFIG",
+    "NPM_CONFIG_GLOBALCONFIG",
+]
+
+
+@pytest.mark.parametrize("key", _REGISTRY_OVERRIDE_KEYS)
+def test_sanitize_mcp_env_rejects_registry_overrides(key):
+    with pytest.raises(ValueError):
+        sanitize_mcp_env({key: "http://evil.example"})
+
+
+def test_sanitize_mcp_env_rejects_lowercase_registry_overrides():
+    # _is_reserved_env_key は upper 比較なので小文字も拒否される（回帰確認）
+    with pytest.raises(ValueError):
+        sanitize_mcp_env({"npm_config_registry": "http://evil"})
+    with pytest.raises(ValueError):
+        sanitize_mcp_env({"uv_index_url": "http://evil"})
+
+
+# パッケージ DL の MitM を塞ぐ。プロキシ / CA 信頼 /
+# TLS 検証無効化系の env を拒否する。TS 側 (mcp-validation.env.test.ts の
+# PROXY_CA_OVERRIDE_KEYS) と同一キー集合で同期させること。npm/pip/uv 固有キーは既存
+# プレフィックスでカバー済みのため、ここではプレフィックスを持たない汎用・Node・Python・
+# curl・OpenSSL・git 系を列挙する。
+_PROXY_CA_OVERRIDE_KEYS = [
+    # 汎用プロキシ
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "FTP_PROXY",
+    # Node CA / TLS
+    "NODE_EXTRA_CA_CERTS",
+    "NODE_TLS_REJECT_UNAUTHORIZED",
+    # Python / curl / OpenSSL CA
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    # git
+    "GIT_SSL_CAINFO",
+    "GIT_SSL_NO_VERIFY",
+    "GIT_PROXY_COMMAND",
+]
+
+
+@pytest.mark.parametrize("key", _PROXY_CA_OVERRIDE_KEYS)
+def test_sanitize_mcp_env_rejects_proxy_ca_overrides(key):
+    with pytest.raises(ValueError):
+        sanitize_mcp_env({key: "http://evil.example"})
+
+
+def test_sanitize_mcp_env_rejects_lowercase_proxy_ca_overrides():
+    # _is_reserved_env_key は upper 比較なので小文字も拒否される（回帰確認）
+    with pytest.raises(ValueError):
+        sanitize_mcp_env({"http_proxy": "http://evil"})
+    with pytest.raises(ValueError):
+        sanitize_mcp_env({"node_extra_ca_certs": "/tmp/evil-ca.pem"})
+
+
+# HOME をユーザー入力で上書きさせない。
+# TS 側 sanitizeMcpEnv と同期。HOME を攻撃者制御ディレクトリに向けると uvx/npx や
+# その子プロセス (pip/git) の設定ファイル探索先を差し替えられるため拒否する。
+def test_sanitize_mcp_env_rejects_home():
+    with pytest.raises(ValueError):
+        sanitize_mcp_env({"HOME": "/tmp/attacker"})
+    # _is_reserved_env_key は upper 比較なので小文字 home も拒否される（回帰確認）
+    with pytest.raises(ValueError):
+        sanitize_mcp_env({"home": "/tmp/attacker"})
+
+
+def test_sanitize_mcp_env_allows_normal_keys():
+    safe = sanitize_mcp_env({"API_KEY": "sk-xxx", "MY_TOKEN": "abc"})
+    assert safe["API_KEY"] == "sk-xxx"
+    assert safe["MY_TOKEN"] == "abc"
+
+
+def test_validate_stdio_config_rejects_registry_override_env():
+    with pytest.raises(ValueError):
+        validate_stdio_config(
+            {
+                "command": "uvx",
+                "args": [],
+                "env": {"NPM_CONFIG_REGISTRY": "http://evil"},
+            }
+        )
+
+
+# MCP HTTP トランスポートのリダイレクト追従を無効化した
+# httpx クライアントファクトリが follow_redirects=False を強制することを担保する。
+# ネットワーク非依存（クライアントは生成して即 close するだけ）。
+def test_no_redirect_http_client_disables_follow():
+    from tools.mcp_validation import create_no_redirect_mcp_http_client
+
+    client = create_no_redirect_mcp_http_client()
+    assert client.follow_redirects is False
+    import anyio
+
+    anyio.run(client.aclose)
+
+
+# mcp_tool.py が不正 config 時に server_cfg を verbatim
+# ログ出力していた情報漏洩を防ぐマスキング関数（TS の maskToolConfiguration をミラー）の
+# 純粋ユニットテスト。ネットワーク非依存。
+def test_mask_mcp_server_config_masks_headers_env_and_clones():
+    cfg = {
+        "url": "https://example.com/mcp",
+        "headers": {"Authorization": "Bearer sk-secret", "X-Api-Key": "sk-secret"},
+        "env": {"API_KEY": "sk-secret", "TOKEN": "sk-secret"},
+    }
+    masked = mask_mcp_server_config(cfg)
+
+    # headers / env はキー名を保持し値のみ ***REDACTED***
+    assert masked["headers"] == {
+        "Authorization": "***REDACTED***",
+        "X-Api-Key": "***REDACTED***",
+    }
+    assert masked["env"] == {"API_KEY": "***REDACTED***", "TOKEN": "***REDACTED***"}
+    # クローンであり元 cfg は変更されない
+    assert cfg["headers"]["Authorization"] == "Bearer sk-secret"
+    assert cfg["env"]["API_KEY"] == "sk-secret"
+
+
+def test_mask_mcp_server_config_masks_args_and_preserves_count():
+    cfg = {"command": "uvx", "args": ["--api-key", "sk-secret", "mcp-server"]}
+    masked = mask_mcp_server_config(cfg)
+
+    assert masked["args"] == ["***REDACTED***", "***REDACTED***", "***REDACTED***"]
+    # 件数（長さ）は保持
+    assert len(masked["args"]) == len(cfg["args"])
+    # 元 cfg は変更されない
+    assert cfg["args"] == ["--api-key", "sk-secret", "mcp-server"]
+
+
+def test_mask_mcp_server_config_masks_url_secrets():
+    cfg = {"url": "https://user:pass@example.com/mcp?api_key=sk-secret&mode=fast"}
+    masked = mask_mcp_server_config(cfg)
+
+    url = masked["url"]
+    # host / path / クエリキーは保持
+    assert urlparse(url).hostname == "example.com"
+    assert "/mcp" in url
+    assert "api_key=" in url
+    assert "mode=" in url
+    # userinfo とクエリ値はマスクされ秘密が消えている
+    assert "user" not in url
+    assert "pass" not in url
+    assert "sk-secret" not in url
+
+
+def test_mask_url_secrets_unparseable_drops_query():
+    # urlparse が例外を投げる（不正ポート）入力で except 経路へ落ち、? 以降を落とす。
+    # 秘密を含まず、? も残らないこと（防御的）。
+    out = _mask_url_secrets("http://example.com:99999999999/p?api_key=sk-secret")
+    assert "sk-secret" not in out
+    assert "?" not in out
+
+
+def test_mask_mcp_server_config_non_dict_returned_as_is():
+    assert mask_mcp_server_config("foo") == "foo"
+    assert mask_mcp_server_config(None) is None
+
+
+# MCP HTTP の TOCTOU(DNS rebinding) 緩和。
+# resolve_and_validate_mcp_url が検証時に安全と確認した IP を返し（接続時のピン留め元）、
+# ピン留め transport が follow_redirects=False と host/Host/sni_hostname を設定することを
+# 検証する。ネットワーク非依存（getaddrinfo を monkeypatch、transport は直接呼ぶ）。
+
+
+def _fake_getaddrinfo(addresses):
+    """getaddrinfo の戻り（(family, type, proto, canonname, sockaddr) のリスト）を作る。"""
+
+    def _impl(host, port, *args, **kwargs):
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", (addr, 0))
+            for addr in addresses
+        ]
+
+    return _impl
+
+
+def test_resolve_and_validate_public_ip_literal_returns_itself():
+    # 公開IPリテラルは解決せず [そのIP] を返す（挙動不変）。
+    hostname, ips = resolve_and_validate_mcp_url("https://93.184.216.34/mcp")
+    assert hostname == "93.184.216.34"
+    assert ips == ["93.184.216.34"]
+
+
+def test_resolve_and_validate_blocked_ip_literal_raises():
+    # 内部IPリテラル（IMDS）は ValueError。
+    with pytest.raises(ValueError):
+        resolve_and_validate_mcp_url("http://169.254.169.254/latest/meta-data")
+
+
+def test_resolve_and_validate_public_hostname_returns_safe_ips(monkeypatch):
+    monkeypatch.setattr(
+        socket, "getaddrinfo", _fake_getaddrinfo(["93.184.216.34", "8.8.8.8"])
+    )
+    hostname, ips = resolve_and_validate_mcp_url("https://example.com/mcp")
+    assert hostname == "example.com"
+    assert ips == ["93.184.216.34", "8.8.8.8"]
+
+
+def test_resolve_and_validate_mixed_public_and_internal_raises(monkeypatch):
+    # 公開と内部が混在 → フェイルクローズ（ValueError）。
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        _fake_getaddrinfo(["93.184.216.34", "169.254.169.254"]),
+    )
+    with pytest.raises(ValueError):
+        resolve_and_validate_mcp_url("https://example.com/mcp")
+
+
+def test_resolve_and_validate_all_internal_raises(monkeypatch):
+    # 全て内部 → フェイルクローズ（ValueError）。
+    monkeypatch.setattr(
+        socket, "getaddrinfo", _fake_getaddrinfo(["10.0.0.5", "169.254.169.254"])
+    )
+    with pytest.raises(ValueError):
+        resolve_and_validate_mcp_url("https://internal.example/mcp")
+
+
+def test_resolve_and_validate_unresolvable_raises(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise socket.gaierror("name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _raise)
+    with pytest.raises(ValueError):
+        resolve_and_validate_mcp_url("https://nope.example/mcp")
+
+
+def test_pinned_transport_sets_host_hostheader_and_sni_and_no_redirect():
+    # ピン留め factory が follow_redirects=False を維持し、生成 transport の
+    # handle_async_request が url.host=pinned_ip / Host=original_host /
+    # sni_hostname=original_host を設定することを検証（ネットワーク非依存）。
+    import anyio
+    import httpx
+
+    from tools.mcp_validation import (
+        _PinnedAsyncHTTPTransport,
+        create_pinned_mcp_http_client_factory,
+    )
+
+    factory = create_pinned_mcp_http_client_factory(
+        pinned_ip="93.184.216.34", original_host="example.com"
+    )
+    client = factory()
+    try:
+        assert client.follow_redirects is False
+    finally:
+        anyio.run(client.aclose)
+
+    # transport.handle_async_request を直接呼び、super を呼ぶ前の request 改変を観測する。
+    transport = _PinnedAsyncHTTPTransport(
+        pinned_ip="93.184.216.34", original_host="example.com"
+    )
+
+    captured = {}
+
+    async def _fake_super(self, request):
+        captured["host"] = request.url.host
+        captured["host_header"] = request.headers.get("Host")
+        captured["sni"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, request=request)
+
+    # super().handle_async_request を差し替えて I/O を発生させない。
+    orig = httpx.AsyncHTTPTransport.handle_async_request
+    httpx.AsyncHTTPTransport.handle_async_request = _fake_super  # type: ignore[assignment]
+    try:
+        request = httpx.Request("GET", "https://example.com/mcp")
+        anyio.run(transport.handle_async_request, request)
+    finally:
+        httpx.AsyncHTTPTransport.handle_async_request = orig  # type: ignore[assignment]
+
+    assert captured["host"] == "93.184.216.34"
+    assert captured["host_header"] == "example.com"
+    assert captured["sni"] == "example.com"
+
+
+def test_mask_mcp_server_config_no_secret_leaks_in_str():
+    # 回帰確認: 秘密文字列が str(masked) に一切現れない。
+    cfg = {
+        "url": "https://example.com/mcp?api_key=sk-secret",
+        "headers": {"Authorization": "Bearer sk-secret"},
+        "env": {"API_KEY": "sk-secret"},
+        "args": ["--token", "sk-secret"],
+    }
+    masked = mask_mcp_server_config(cfg)
+    assert "sk-secret" not in str(masked)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/review-item-processor/tests/test_citation.py
+++ b/review-item-processor/tests/test_citation.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python3
-"""Citation tests for agent.py.
+"""
+Tests for the citation functionality in agent.py.
 
-Offline tests cover _should_use_document_block (routing) and
-_extract_citations_text (parsing). An opt-in Bedrock integration test runs only
-with RUN_BEDROCK_INTEGRATION=1 (needs AWS credentials).
+Run with: pytest tests/test_citation.py -v
+
+Offline tests (run by default, no AWS access) cover:
+  - _should_use_document_block: routing between the document block path
+    (PDF with citations) and the file_read tool path.
+  - _extract_citations_text: parsing the citations array from the model's
+    JSON response.
+
+An opt-in integration test runs a real review over the bundled sample PDF
+via Amazon Bedrock. It is skipped unless RUN_BEDROCK_INTEGRATION=1 is set
+(requires AWS credentials and incurs Bedrock charges):
+
+  RUN_BEDROCK_INTEGRATION=1 pytest tests/test_citation.py -v
 """
 import os
 import sys
@@ -14,12 +25,12 @@ import pytest
 # Add parent directory to path so `import agent` works when run from any cwd.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import agent
-from agent import _extract_citations_text, _should_use_document_block
-from model_config import ModelConfig
+import agent  # noqa: E402
+from agent import _extract_citations_text, _should_use_document_block  # noqa: E402
+from model_config import ModelConfig  # noqa: E402
 
 # A registered model that supports the document block + citations.
-CITATION_MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+CITATION_MODEL_ID = "global.anthropic.claude-sonnet-5"
 # An unregistered model falls back to _DEFAULT_CONFIG (no document block).
 UNKNOWN_MODEL_ID = "example.unknown-model-v1"
 

--- a/review-item-processor/tests/test_model_config.py
+++ b/review-item-processor/tests/test_model_config.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Tests for model_config.py — Claude Opus 4.8 registration.
+
+Run with: pytest tests/test_model_config.py -v
+
+Covers:
+  ModelConfig.create() resolves every form (global / us / eu / jp / au /
+  base) of the Opus 4.8 modelId to a registered config.
+"""
+import os
+import sys
+
+import pytest
+
+# Add parent directory to path so `import model_config` works when run from any cwd.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from model_config import ModelConfig, _MODEL_REGISTRY  # noqa: E402
+
+
+# All six Opus 4.8 forms that must be registered (global / geo / base).
+OPUS_4_8_MODEL_IDS = [
+    "global.anthropic.claude-opus-4-8",
+    "us.anthropic.claude-opus-4-8",
+    "eu.anthropic.claude-opus-4-8",
+    "jp.anthropic.claude-opus-4-8",
+    "au.anthropic.claude-opus-4-8",
+    "anthropic.claude-opus-4-8",
+]
+
+EXPECTED_DISPLAY_NAMES = {
+    "global.anthropic.claude-opus-4-8": "Claude Opus 4.8 (Global)",
+    "us.anthropic.claude-opus-4-8": "Claude Opus 4.8 (US)",
+    "eu.anthropic.claude-opus-4-8": "Claude Opus 4.8 (EU)",
+    "jp.anthropic.claude-opus-4-8": "Claude Opus 4.8 (JP)",
+    "au.anthropic.claude-opus-4-8": "Claude Opus 4.8 (AU)",
+    "anthropic.claude-opus-4-8": "Claude Opus 4.8",
+}
+
+
+@pytest.mark.parametrize("model_id", OPUS_4_8_MODEL_IDS)
+def test_opus_4_8_registered(model_id):
+    """Each Opus 4.8 form must be present in the registry."""
+    assert model_id in _MODEL_REGISTRY
+
+
+@pytest.mark.parametrize("model_id", OPUS_4_8_MODEL_IDS)
+def test_opus_4_8_capability_flags(model_id):
+    """All Opus 4.8 entries support document block / citation / caching."""
+    config = ModelConfig.create(model_id)
+    assert config.supports_document_block is True
+    assert config.supports_citation is True
+    assert config.supports_caching is True
+
+
+@pytest.mark.parametrize("model_id", OPUS_4_8_MODEL_IDS)
+def test_opus_4_8_display_name(model_id):
+    """Display names match the spec exactly."""
+    config = ModelConfig.create(model_id)
+    assert config.display_name == EXPECTED_DISPLAY_NAMES[model_id]
+
+
+@pytest.mark.parametrize("model_id", OPUS_4_8_MODEL_IDS)
+def test_opus_4_8_provisional_pricing(model_id):
+    """Provisional pricing matches Opus 4.6/4.7 ($5 / $25 per 1M tokens)."""
+    config = ModelConfig.create(model_id)
+    assert config.input_per_1m == 5.0
+    assert config.output_per_1m == 25.0
+
+
+def test_opus_4_8_unknown_region_falls_back_to_base():
+    """
+    An unregistered region prefix for Opus 4.8 falls back via base model id
+    (create() strips the region prefix) and resolves to the base entry.
+    """
+    config = ModelConfig.create("ap.anthropic.claude-opus-4-8")
+    assert config.display_name == "Claude Opus 4.8"

--- a/review-item-processor/tests/test_no_feedback_injection.py
+++ b/review-item-processor/tests/test_no_feedback_injection.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Regression tests for feedback_aggregator decommission.
+
+Verifies that the prompt generation functions no longer inject the historical
+feedback section (<HISTORICAL_FEEDBACK>) into the review prompts, while the
+other legitimate prompt inputs (check name / description / tool config / language)
+are still passed through.
+
+Run with: pytest tests/test_no_feedback_injection.py -v
+"""
+import os
+import sys
+
+# Add parent directory to path so `agent` can be imported.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import agent  # noqa: E402
+
+# Marker string that previously appeared when feedback summaries were injected.
+FEEDBACK_MARKER = "<HISTORICAL_FEEDBACK>"
+
+# A feedback_summary value that, under the old behaviour, would have been
+# embedded verbatim into the prompt. It must NOT appear in any generated prompt.
+SAMPLE_FEEDBACK = "PAST_REVIEWER_NOTE: storage area was previously blocking the exit"
+
+CHECK_NAME = "保管スペース確保"
+CHECK_DESCRIPTION = "指定エリア内に整理保管され、避難経路を塞いでいない"
+LANGUAGE_NAME = "日本語"
+MODEL_ID = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+
+
+def test_document_prompt_legacy_has_no_historical_feedback():
+    """Legacy (non-citation) document prompt must not contain <HISTORICAL_FEEDBACK>."""
+    prompt = agent.get_document_review_prompt(
+        LANGUAGE_NAME,
+        CHECK_NAME,
+        CHECK_DESCRIPTION,
+        use_citations=False,
+        feedback_summary=SAMPLE_FEEDBACK,
+    )
+    assert FEEDBACK_MARKER not in prompt
+    assert SAMPLE_FEEDBACK not in prompt
+    # Legitimate inputs are still present.
+    assert CHECK_NAME in prompt
+    assert CHECK_DESCRIPTION in prompt
+    assert LANGUAGE_NAME in prompt
+
+
+def test_document_prompt_with_citations_has_no_historical_feedback():
+    """Citation document prompt must not contain <HISTORICAL_FEEDBACK>."""
+    prompt = agent.get_document_review_prompt(
+        LANGUAGE_NAME,
+        CHECK_NAME,
+        CHECK_DESCRIPTION,
+        use_citations=True,
+        feedback_summary=SAMPLE_FEEDBACK,
+    )
+    assert FEEDBACK_MARKER not in prompt
+    assert SAMPLE_FEEDBACK not in prompt
+    assert CHECK_NAME in prompt
+    assert CHECK_DESCRIPTION in prompt
+    assert LANGUAGE_NAME in prompt
+
+
+def test_image_prompt_has_no_historical_feedback():
+    """Image review prompt must not contain <HISTORICAL_FEEDBACK>."""
+    prompt = agent.get_image_review_prompt(
+        LANGUAGE_NAME,
+        CHECK_NAME,
+        CHECK_DESCRIPTION,
+        MODEL_ID,
+        feedback_summary=SAMPLE_FEEDBACK,
+    )
+    assert FEEDBACK_MARKER not in prompt
+    assert SAMPLE_FEEDBACK not in prompt
+    assert CHECK_NAME in prompt
+    assert CHECK_DESCRIPTION in prompt
+    assert LANGUAGE_NAME in prompt
+
+
+def test_document_prompt_identical_with_and_without_feedback_summary():
+    """feedback_summary must have no effect on the generated document prompt."""
+    base = agent.get_document_review_prompt(
+        LANGUAGE_NAME,
+        CHECK_NAME,
+        CHECK_DESCRIPTION,
+        use_citations=False,
+        feedback_summary=None,
+    )
+    with_feedback = agent.get_document_review_prompt(
+        LANGUAGE_NAME,
+        CHECK_NAME,
+        CHECK_DESCRIPTION,
+        use_citations=False,
+        feedback_summary=SAMPLE_FEEDBACK,
+    )
+    assert base == with_feedback
+
+
+def test_image_prompt_identical_with_and_without_feedback_summary():
+    """feedback_summary must have no effect on the generated image prompt."""
+    base = agent.get_image_review_prompt(
+        LANGUAGE_NAME,
+        CHECK_NAME,
+        CHECK_DESCRIPTION,
+        MODEL_ID,
+        feedback_summary=None,
+    )
+    with_feedback = agent.get_image_review_prompt(
+        LANGUAGE_NAME,
+        CHECK_NAME,
+        CHECK_DESCRIPTION,
+        MODEL_ID,
+        feedback_summary=SAMPLE_FEEDBACK,
+    )
+    assert base == with_feedback
+
+
+def test_build_feedback_section_helper_removed():
+    """The _build_feedback_section helper must no longer exist on the module."""
+    assert not hasattr(agent, "_build_feedback_section")

--- a/review-item-processor/tests/test_prompt_caching.py
+++ b/review-item-processor/tests/test_prompt_caching.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 """
-Tests for document/image prompt caching (auto cache strategy).
+Tests for document/image prompt caching.
+
+Covers three layers:
+  - _apply_cache_config: the agent enables the auto cache strategy.
+  - The message shape built by the document-block path: an explicit
+    cachePoint sits BETWEEN the document blocks and the per-item prompt,
+    so the cached prefix is identical across review items that share the
+    same documents (cross-item cache reuse).
+  - SDK contract: strands honors that manually placed cachePoint instead
+    of moving it to the end of the message (behavior introduced in
+    strands-agents 1.52.0; the pyproject floor is pinned accordingly).
 """
 
 import os
@@ -31,14 +41,25 @@ def test_supports_caching_gates_cache_config():
     assert agent.supports_caching("some.unregistered.model-id") is False
 
 
-def test_bedrock_auto_strategy_caches_after_document_block():
-    """SDK contract: cache_config=auto puts the cachePoint AFTER a document, so
-    the document ends up inside the cached prefix."""
+def test_placed_cache_point_between_document_and_prompt_is_honored():
+    """SDK contract for cross-item document caching.
+
+    The document-block path builds `[document..., cachePoint, per-item text]`.
+    strands >= 1.52.0 must honor that placed cachePoint where it sits
+    (`_honor_placed_cache_point`), so the cached prefix ends at the documents
+    and stays identical across review items. If the SDK moved the point to
+    the end of the message, the per-item text would enter the prefix and
+    cross-item reuse would silently break — this test is the canary for that.
+    It intentionally exercises the private `_format_bedrock_messages` to pin
+    the SDK behavior; revisit it whenever strands-agents is upgraded.
+    """
     model = BedrockModel(
         model_id="global.anthropic.claude-sonnet-4-6",
+        region_name="us-west-2",
         cache_config=CacheConfig(strategy="auto"),
     )
 
+    # Same shape as _run_agent_with_document_block: docs, cachePoint, prompt.
     messages: Messages = [
         {
             "role": "user",
@@ -50,6 +71,7 @@ def test_bedrock_auto_strategy_caches_after_document_block():
                         "source": {"bytes": b"%PDF-1.4 fake pdf bytes"},
                     }
                 },
+                {"cachePoint": {"type": "default"}},
                 {"text": "Evaluate this document against the check item."},
             ],
         }
@@ -60,7 +82,36 @@ def test_bedrock_auto_strategy_caches_after_document_block():
     content = formatted[0]["content"]
     cache_idxs = [i for i, b in enumerate(content) if "cachePoint" in b]
     doc_idxs = [i for i, b in enumerate(content) if "document" in b]
+    text_idxs = [i for i, b in enumerate(content) if "text" in b]
 
-    assert cache_idxs, "auto strategy must inject a cachePoint"
-    assert doc_idxs, "document block should be preserved"
-    assert max(doc_idxs) < max(cache_idxs)  # doc must precede the cache point
+    assert len(cache_idxs) == 1, "exactly one cachePoint must survive"
+    assert doc_idxs and text_idxs, "document and text blocks must be preserved"
+    # The property that makes cross-item reuse possible:
+    # every document precedes the cachePoint, and the cachePoint precedes
+    # the per-item prompt text.
+    assert max(doc_idxs) < cache_idxs[0] < min(text_idxs)
+
+
+def test_auto_strategy_appends_cache_point_when_none_placed():
+    """Without a placed point (file_read/image path), auto appends one at the
+    end of the last user message. The cached prefix then includes the per-item
+    prompt, which only enables intra-item multi-turn reuse — kept as a
+    regression pin so the difference between the two paths stays explicit."""
+    model = BedrockModel(
+        model_id="global.anthropic.claude-sonnet-4-6",
+        region_name="us-west-2",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    messages: Messages = [
+        {
+            "role": "user",
+            "content": [{"text": "Per-item prompt text only."}],
+        }
+    ]
+
+    formatted = model._format_bedrock_messages(messages)
+
+    content = formatted[0]["content"]
+    kinds = [next(iter(b.keys())) for b in content]
+    assert kinds == ["text", "cachePoint"]

--- a/review-item-processor/tools/factory.py
+++ b/review-item-processor/tools/factory.py
@@ -36,7 +36,9 @@ def create_custom_tools(
         logger.debug("No tool configuration provided, returning empty tool list")
         return tools
 
-    logger.debug(f"Creating tools with configuration: {tool_config}")
+    # tool_config には MCP 資格情報（headers/env/oauthScopes、
+    # 資格情報を埋め込みうる url）が含まれうるため値をログ出力しない。トップレベルキーのみ記録する。
+    logger.debug(f"Creating tools; configuration keys={sorted(tool_config.keys())}")
 
     # Code Interpreter
     if tool_config.get("codeInterpreter", False):

--- a/review-item-processor/tools/file_access.py
+++ b/review-item-processor/tools/file_access.py
@@ -1,0 +1,244 @@
+"""
+file_read / image_reader ツールの
+ローカルファイルインクルージョン(LFI)対策。
+
+strands_tools の素の file_read / image_reader はパス束縛が無いため、プロンプト
+インジェクション経由で /proc/self/environ や /etc/passwd 等の機微ファイルを LLM agent に
+読ませることができる（image_reader は PIL が読める画像ファイルに限定されるが、それでも
+許可外パスの読み取り＝LFI に該当する）。本モジュールは「許可ディレクトリ配下のファイルのみ」を
+読める束縛版を生成するファクトリ create_bounded_file_read_tool /
+create_bounded_image_reader_tool を提供し、agent.py がジョブ固有の作業ディレクトリ
+（process_review_from_s3 が S3 から DL した temp_dir）に束縛して使用する。
+
+設計方針:
+- ツール名は必ず "file_read" / "image_reader" を維持する（プロンプトがツール名を参照する
+  ため、名前を変えると LLM がツールを見つけられず審査が回帰する）。
+- file_read の mode は安全な読み取り系のみ allowlist（view/lines/search/preview/stats）。
+  find/document/diff/time_machine/chunk は拒否する（find は許可外ファイルの列挙、
+  diff/time_machine は comparison_path / git 経由で許可外参照やコマンド実行に至りうるため）。
+- パスは realpath 正規化し commonpath で許可ディレクトリ配下か判定する（prefix 文字列
+  一致の罠を回避: /tmp/jobX と /tmp/jobXY を誤って配下扱いしない）。
+- '..' / '~' / グロブメタ文字 (*?[) を含むパスは拒否（トラバーサル・ワイルドカード列挙を封鎖）。
+- 許可ディレクトリ側・候補側の双方に realpath を適用する（/tmp -> /private/tmp の symlink 環境で
+  正当なファイルを誤って拒否しないため）。
+- image_reader は素の file_read のような複数パス（カンマ区切り）/ mode を持たず、単一の
+  image_path のみを受ける。それ以外の検証（トラバーサル・グロブ・~ 展開・配下判定）は
+  file_read と完全に同型にし、束縛ロジックを共有する（_resolve_within_allowed）。
+"""
+
+import os
+from typing import Any, Dict, List
+
+from logger import logger
+from strands.tools import tool
+from strands.types.tools import AgentTool
+from strands_tools.file_read import file_read as _strands_file_read
+from strands_tools.image_reader import image_reader as _strands_image_reader
+
+# 安全な読み取り系モードのみ許可する。
+# - find: ディレクトリ走査で許可外ファイルを列挙しうる
+# - document: Bedrock document ブロック生成（許可外ファイルを埋め込みうる）
+# - diff: comparison_path で許可外ファイルを読みうる
+# - time_machine: git サブプロセスを起動しうる
+# - chunk: バイトオフセット読み取りは本ユースケースで不要
+_ALLOWED_MODES = {"view", "lines", "search", "preview", "stats"}
+
+# パスに含まれていたら拒否するメタ文字（グロブ・ワイルドカード列挙の封鎖）。
+_GLOB_METACHARS = ("*", "?", "[")
+
+
+def _normalize_allowed_dirs(allowed_dirs: List[str]) -> List[str]:
+    """許可ディレクトリを realpath 正規化する（symlink 解決込み）。
+
+    空文字・None 等の不正要素は除外する（フェイルクローズ）。file_read /
+    image_reader 双方の束縛ファクトリで共有する。
+    """
+    return [
+        os.path.realpath(d)
+        for d in (allowed_dirs or [])
+        if isinstance(d, str) and d
+    ]
+
+
+def _is_within_allowed(candidate: str, allowed: List[str]) -> bool:
+    """candidate（解決済み実パス）が許可ディレクトリのいずれかの配下か判定する。
+
+    commonpath が base に一致 == real が base 配下（prefix 文字列一致の罠を回避:
+    /tmp/jobX と /tmp/jobXY を誤って配下扱いしない）。
+    """
+    if not allowed:
+        return False
+    real = os.path.realpath(candidate)
+    for base in allowed:
+        try:
+            if os.path.commonpath([real, base]) == base:
+                return True
+        except ValueError:
+            # 異なるドライブ等で commonpath が失敗した場合は配下ではない扱い。
+            continue
+    return False
+
+
+def _error(message: str) -> Dict[str, Any]:
+    return {"status": "error", "content": [{"text": message}]}
+
+
+def _has_disallowed_path_chars(path: str) -> bool:
+    """トラバーサル('..')・ホーム展開('~')・グロブメタ文字(*?[)を含むか判定する。"""
+    return ".." in path or "~" in path or any(m in path for m in _GLOB_METACHARS)
+
+
+def create_bounded_file_read_tool(allowed_dirs: List[str]) -> AgentTool:
+    """許可ディレクトリ配下のファイルのみ読める束縛版 file_read ツールを生成する。
+
+    Args:
+        allowed_dirs: 読み取りを許可するディレクトリの絶対パスのリスト。
+            内部で realpath 正規化してクロージャに捕捉する。
+
+    Returns:
+        @tool でデコレートされた束縛版 file_read（ツール名は "file_read"）。
+    """
+    # 許可ディレクトリを realpath 正規化して捕捉する（symlink 解決込み）。
+    _allowed = _normalize_allowed_dirs(allowed_dirs)
+
+    @tool(
+        name="file_read",
+        description=(
+            "Read the contents of attached review files. "
+            "Access is restricted to the files provided for this review job. "
+            "Supported modes: view, lines, search, preview, stats."
+        ),
+    )
+    def file_read(path: str, mode: str = "view", **kwargs: Any) -> Dict[str, Any]:
+        """Read attached review files (restricted to this job's files)."""
+        try:
+            if not isinstance(path, str) or not path:
+                return _error("file_read error: 'path' must be a non-empty string")
+
+            if mode not in _ALLOWED_MODES:
+                # 汎用文言（許可外パスは含めない）。
+                return _error(
+                    f"file_read error: mode '{mode}' is not permitted. "
+                    f"Allowed modes: {', '.join(sorted(_ALLOWED_MODES))}"
+                )
+
+            # トラバーサル・ホーム展開・グロブメタ文字を含むパスは拒否する。
+            if _has_disallowed_path_chars(path):
+                return _error(
+                    "file_read error: path contains disallowed characters "
+                    "('..', '~', or glob metacharacters)"
+                )
+
+            # 複数パス（カンマ区切り）を許容しつつ、各パスを許可判定する。
+            raw_paths = [p.strip() for p in path.split(",") if p.strip()]
+            if not raw_paths:
+                return _error("file_read error: no valid path provided")
+
+            resolved_paths = []
+            for p in raw_paths:
+                # 相対パスは allowed_dirs[0] 基準で解決する。
+                if not os.path.isabs(p):
+                    base = _allowed[0] if _allowed else os.getcwd()
+                    p = os.path.join(base, p)
+                resolved = os.path.realpath(p)
+                if not _is_within_allowed(resolved, _allowed):
+                    # 汎用文言（許可外の実パスは含めない＝情報漏洩を防ぐ）。
+                    return _error(
+                        "file_read error: access to the requested path is not permitted"
+                    )
+                resolved_paths.append(resolved)
+
+            # 全パスが許可内 → 解決済み実パスで素の file_read（ToolUse dict 委譲）を呼ぶ。
+            tool_input: Dict[str, Any] = dict(kwargs)
+            tool_input["path"] = ",".join(resolved_paths)
+            tool_input["mode"] = mode
+
+            return _strands_file_read(
+                {"toolUseId": "bounded-file-read", "input": tool_input}
+            )
+
+        except Exception as e:  # noqa: BLE001 - ツールは例外を握ってエラー返却する
+            logger.error(f"bounded file_read failed: {e}")
+            return _error(f"file_read error: {e}")
+
+    logger.debug(
+        f"Created bounded file_read tool restricted to {len(_allowed)} director(y/ies)"
+    )
+    return file_read
+
+
+def create_bounded_image_reader_tool(allowed_dirs: List[str]) -> AgentTool:
+    """許可ディレクトリ配下の画像のみ読める束縛版 image_reader ツールを生成する。
+
+    素の strands_tools.image_reader は image_path を
+    expanduser で ~ 展開し、存在すれば任意パスの画像を読み込むため LFI に至る
+    （/proc/self/environ 等のテキストは PIL が弾くが、許可外ディレクトリの画像は読める）。
+    create_bounded_file_read_tool と同型に、image_path を realpath+commonpath で
+    allowed_dirs 配下に検証し、'..'/'~'/グロブメタ文字を拒否してから素の image_reader へ委譲する。
+
+    Args:
+        allowed_dirs: 読み取りを許可するディレクトリの絶対パスのリスト。
+            内部で realpath 正規化してクロージャに捕捉する。
+
+    Returns:
+        @tool でデコレートされた束縛版 image_reader（ツール名は "image_reader"）。
+    """
+    # 許可ディレクトリを realpath 正規化して捕捉する（file_read と共有のヘルパ）。
+    _allowed = _normalize_allowed_dirs(allowed_dirs)
+
+    @tool(
+        name="image_reader",
+        description=(
+            "Read an attached review image and return it for analysis via the "
+            "Converse API. Access is restricted to the image files provided for "
+            "this review job."
+        ),
+    )
+    def image_reader(image_path: str, **kwargs: Any) -> Dict[str, Any]:
+        """Read an attached review image (restricted to this job's files)."""
+        try:
+            if not isinstance(image_path, str) or not image_path:
+                return _error(
+                    "image_reader error: 'image_path' must be a non-empty string"
+                )
+
+            # トラバーサル・ホーム展開・グロブメタ文字を含むパスは拒否する
+            # （素の image_reader は expanduser で ~ を展開してしまうため、ここで遮断する）。
+            if _has_disallowed_path_chars(image_path):
+                return _error(
+                    "image_reader error: path contains disallowed characters "
+                    "('..', '~', or glob metacharacters)"
+                )
+
+            # 単一パスのみ受ける（image_reader はカンマ区切り/mode を持たない）。
+            candidate = image_path.strip()
+            if not candidate:
+                return _error("image_reader error: no valid path provided")
+
+            # 相対パスは allowed_dirs[0] 基準で解決する（file_read と同一方針）。
+            if not os.path.isabs(candidate):
+                base = _allowed[0] if _allowed else os.getcwd()
+                candidate = os.path.join(base, candidate)
+            resolved = os.path.realpath(candidate)
+            if not _is_within_allowed(resolved, _allowed):
+                # 汎用文言（許可外の実パスは含めない＝情報漏洩を防ぐ）。
+                return _error(
+                    "image_reader error: access to the requested path is not permitted"
+                )
+
+            # 許可内 → 解決済み実パスで素の image_reader（ToolUse dict 委譲）を呼ぶ。
+            tool_input: Dict[str, Any] = dict(kwargs)
+            tool_input["image_path"] = resolved
+
+            return _strands_image_reader(
+                {"toolUseId": "bounded-image-reader", "input": tool_input}
+            )
+
+        except Exception as e:  # noqa: BLE001 - ツールは例外を握ってエラー返却する
+            logger.error(f"bounded image_reader failed: {e}")
+            return _error(f"image_reader error: {e}")
+
+    logger.debug(
+        f"Created bounded image_reader tool restricted to {len(_allowed)} director(y/ies)"
+    )
+    return image_reader

--- a/review-item-processor/tools/mcp_tool.py
+++ b/review-item-processor/tools/mcp_tool.py
@@ -8,6 +8,14 @@ from mcp.client.stdio import (
 )
 from mcp.client.streamable_http import streamablehttp_client
 from logger import logger
+from tools.mcp_validation import (
+    _mask_url_secrets,
+    create_pinned_mcp_http_client_factory,
+    mask_mcp_server_config,
+    resolve_and_validate_mcp_url,
+    validate_stdio_config,
+)
+
 
 # uvx が MCP サーバの依存を解決するときに適用する制約ファイル (mcp<2)。
 # イメージ内では Dockerfile の COPY により /app/mcp-uv-constraints.txt に置かれる
@@ -75,7 +83,11 @@ def create_mcp_clients(mcp_config: Optional[Dict[str, Dict[str, Any]]]) -> List[
                 client = _create_stdio_client(server_cfg, server_name)
             else:
                 error_msg = f"Invalid config: missing url or (command + args)"
-                logger.error(f"Invalid MCP config for '{server_name}': {server_cfg}")
+                # server_cfg は headers/env の秘密・
+                # url の api_key・args 等を含みうるため verbatim 出力せずマスクする。
+                logger.error(
+                    f"Invalid MCP config for '{server_name}': {mask_mcp_server_config(server_cfg)}"
+                )
                 failed_servers.append((server_name, error_msg))
                 continue
 
@@ -124,25 +136,62 @@ def _is_stdio_config(config: Dict[str, Any]) -> bool:
 
 
 def _create_stdio_client(config: Dict[str, Any], server_name: str) -> Optional[MCPClient]:
-    """Create stdio-based MCP client (uvx or npx)."""
+    """Create stdio-based MCP client (uvx or npx).
+
+    TS 側と同一ルールで command/args/env を
+    検証する。command は allowlist（uvx/npx）に限定し、シェルメタ文字を拒否。config.env の
+    予約環境変数は拒否する。検証違反は ValueError（呼び出し側が per-server エラーとして捕捉）。
+    """
     command = config.get("command", "uvx")
     args = config["args"]
 
+    # 検証（不正なら ValueError を送出してフェイルクローズ）。
     # 既存挙動どおり os.environ は無条件展開せず、SDK 既定の安全な env を用いる。
     # 加算するのは UV_CONSTRAINT (mcp<2) のみ（_build_stdio_env 参照）。
+    validate_stdio_config(config)
+
     env = _build_stdio_env()
     client = MCPClient(
         lambda a=args, c=command, e=env: stdio_client(
             StdioServerParameters(command=c, args=a, env=e)
         )
     )
-    logger.debug(f"Created stdio MCP client '{server_name}': {command} {args}")
+    # args は秘密（--api-key 等）を含みうるので件数のみ。
+    # command は allowlist(uvx/npx)済みで非機密。
+    logger.debug(
+        f"Created stdio MCP client '{server_name}': {command} ({len(args)} arg(s))"
+    )
     return client
 
 
 def _create_http_client(config: Dict[str, Any], server_name: str) -> Optional[MCPClient]:
-    """Create HTTP-based MCP client."""
+    """Create HTTP-based MCP client.
+
+    接続先 URL を検証して SSRF を防ぐ。内部 IP /
+    リンクローカル / ループバック / 非 http(s) を拒否し、ホスト名は DNS 解決して全 IP を検査。
+    検証不能時はフェイルクローズ（ValueError）。
+
+    リダイレクト追従を無効化した httpx クライアントを注入し、
+    接続後の 3xx で内部（IMDS/VPC）へ誘導される SSRF サイロ漏れを防ぐ。
+
+    「検証→接続」の2段階で各々が独立に DNS 解決すると
+    TOCTOU(DNS rebinding)で接続先がすり替わりうる。resolve_and_validate_mcp_url が検証時に
+    安全と確認した IP をピン留めして接続する factory を注入し、すり替え窓を閉じる。TLS は
+    元ホスト名(SNI/Host)で検証するため証明書検証は壊さない。
+    """
     url = config["url"].strip()
-    client = MCPClient(lambda u=url: streamablehttp_client(u))
-    logger.debug(f"Created HTTP MCP client '{server_name}': {url}")
+    hostname, safe_ips = resolve_and_validate_mcp_url(url)
+    # 検証済みの安全な IP を接続先へピン留め（複数解決時は先頭を採用）。
+    httpx_client_factory = create_pinned_mcp_http_client_factory(
+        pinned_ip=safe_ips[0], original_host=hostname
+    )
+    client = MCPClient(
+        lambda u=url, f=httpx_client_factory: streamablehttp_client(
+            u, httpx_client_factory=f
+        )
+    )
+    # url の userinfo/クエリ値（api_key 等）はマスクする。
+    logger.debug(
+        f"Created HTTP MCP client '{server_name}': {_mask_url_secrets(url)}"
+    )
     return client

--- a/review-item-processor/tools/mcp_validation.py
+++ b/review-item-processor/tools/mcp_validation.py
@@ -1,0 +1,415 @@
+"""
+MCP ツール実行（stdio / HTTP）の入力検証。
+
+backend/src/api/features/tool-configuration/domain/service/mcp-validation.ts の
+ルールを「同一」にミラーする。TS 側を単一の真実源とし、本ファイルは
+同じ allowlist / メタ文字集合 / 予約環境変数集合 / SSRF 判定ロジックを Python で再現する。
+
+- stdio: 実行ファイルを allowlist（uvx / npx）に限定、command/args のシェル
+  メタ文字を拒否。os.environ を無条件に渡さず（既存の SDK 既定 env を維持）、
+  config.env の予約キーを拒否。
+- http: 接続先 URL のスキーム・ホスト（リンクローカル/ループバック/プライベート/予約）を
+  検証して SSRF を防ぐ。解決失敗・検証不能時は拒否（フェイルクローズ）。
+
+検証違反は ValueError を送出する。呼び出し側（mcp_tool.create_mcp_clients）は ValueError を
+per-server のユーザー修正可能エラーとして捕捉し、当該サーバーをスキップする（フェイルクローズ）。
+"""
+
+import ipaddress
+import re
+import socket
+from typing import Any, Dict, List, Tuple
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+import httpx
+
+# stdio で起動を許可する実行ファイル（basename のみ）。TS 側 ALLOWED_MCP_COMMANDS と一致。
+ALLOWED_MCP_COMMANDS = ["uvx", "npx"]
+
+# command / args に出現を禁止するシェルメタ文字・制御文字（TS 側 SHELL_METACHAR_RE と一致）。
+_SHELL_METACHAR_RE = re.compile(r"""[;&|`$(){}<>\n\r\t*?!\\"' ]""")
+
+# config.env で設定を禁止する予約環境変数。TS 側 RESERVED_ENV_KEYS と一致。
+# UV_CACHE_DIR/UV_TOOL_DIR/NPM_CONFIG_CACHE/NPM_CONFIG_PREFIX は下記の
+# UV_/NPM_CONFIG_ プレフィックスでも一括カバーされるが、可読性のため残す。
+RESERVED_ENV_KEYS = {
+    "PATH",
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "NODE_OPTIONS",
+    "PYTHONPATH",
+    "PYTHONSTARTUP",
+    "BASH_ENV",
+    "ENV",
+    "IFS",
+    # HOME をユーザー入力で上書きさせない。
+    # HOME を攻撃者制御ディレクトリに向けると uvx/npx やその子プロセス (pip/git) の設定ファイル
+    # 探索先（~/.npmrc, ~/.config/uv, ~/.gitconfig 等）を差し替えられる。TS 側 RESERVED_ENV_KEYS
+    # と同期。build_minimal_mcp_env の base_env がシステム値で固定する。
+    "HOME",
+    "UV_CACHE_DIR",
+    "UV_TOOL_DIR",
+    "NPM_CONFIG_CACHE",
+    "NPM_CONFIG_PREFIX",
+    # パッケージ DL の MitM を塞ぐ。
+    # TS 側 RESERVED_ENV_KEYS と同一キー集合で同期させること。プロキシ / CA 信頼 /
+    # TLS 検証無効化系を子プロセス(uvx/npx 及び pip/git)へ渡させない。npm/pip/uv 固有キーは
+    # 既存の NPM_CONFIG_ / PIP_ / UV_ プレフィックスでカバー済みのため、ここでは
+    # プレフィックスを持たない汎用・Node・Python・curl・OpenSSL・git 系のみを列挙する。
+    # 小文字 http_proxy 等も _is_reserved_env_key の upper 比較で一致する。
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "FTP_PROXY",
+    "NODE_EXTRA_CA_CERTS",
+    "NODE_TLS_REJECT_UNAUTHORIZED",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "GIT_SSL_CAINFO",
+    "GIT_SSL_NO_VERIFY",
+    "GIT_PROXY_COMMAND",
+}
+
+# パッケージレジストリ/インデックスの上書き系
+# 環境変数（UV_INDEX_URL / UV_DEFAULT_INDEX / PIP_INDEX_URL / NPM_CONFIG_REGISTRY 等）を
+# プレフィックスで一括拒否する。これらは uvx/npx(+pip) のパッケージ解決先を攻撃者制御
+# レジストリへ向け、悪意パッケージ実行（RCE）に至るため。_is_reserved_env_key は upper
+# 比較なので小文字 npm_config_registry / uv_index_url も一致する。TS 側
+# RESERVED_ENV_PREFIXES と単一真実源で同期させること。
+_RESERVED_ENV_PREFIXES = ("DYLD_", "LD_", "UV_", "PIP_", "NPM_CONFIG_")
+
+_ALLOWED_URL_SCHEMES = ("http", "https")
+
+
+def _is_reserved_env_key(key: str) -> bool:
+    upper = key.upper()
+    if upper in RESERVED_ENV_KEYS:
+        return True
+    return any(upper.startswith(p) for p in _RESERVED_ENV_PREFIXES)
+
+
+def assert_allowed_mcp_command(command: str) -> None:
+    """実行ファイル名 (command) を検証する。"""
+    if not isinstance(command, str) or not command:
+        raise ValueError("MCP command must be a non-empty string")
+    if "/" in command or "\\" in command or _SHELL_METACHAR_RE.search(command):
+        raise ValueError(
+            f"MCP command must be a bare executable name without path "
+            f"separators or shell metacharacters: {command}"
+        )
+    if command not in ALLOWED_MCP_COMMANDS:
+        raise ValueError(
+            f"MCP command not allowed: {command}. "
+            f"Allowed: {', '.join(ALLOWED_MCP_COMMANDS)}"
+        )
+
+
+def assert_safe_mcp_args(args: Any) -> None:
+    """args（配列）を検証する。各要素は文字列でシェルメタ文字を含まないこと。"""
+    if not isinstance(args, list):
+        raise ValueError("MCP args must be a list of strings")
+    for arg in args:
+        if not isinstance(arg, str):
+            raise ValueError("MCP args must all be strings")
+        if _SHELL_METACHAR_RE.search(arg):
+            raise ValueError(
+                f"MCP arg contains disallowed shell metacharacters: {arg}"
+            )
+
+
+def sanitize_mcp_env(env: Any) -> Dict[str, str]:
+    """config.env から予約キーを除いた安全なエントリのみを返す。予約キーは拒否。"""
+    if env is None:
+        return {}
+    if not isinstance(env, dict):
+        raise ValueError("MCP env must be a mapping of string to string")
+    safe: Dict[str, str] = {}
+    for key, value in env.items():
+        if _is_reserved_env_key(str(key)):
+            raise ValueError(
+                f"MCP env must not set reserved environment variable: {key}"
+            )
+        if not isinstance(value, str):
+            raise ValueError(f"MCP env value for {key} must be a string")
+        safe[str(key)] = value
+    return safe
+
+
+def validate_stdio_config(config: Dict[str, Any]) -> Dict[str, str]:
+    """stdio 設定 (command / args / env) を一括検証する。
+
+    検証を通過した安全な env（予約キー除外済み）を返す。
+    """
+    command = config.get("command", "uvx")
+    assert_allowed_mcp_command(command)
+    assert_safe_mcp_args(config.get("args", []))
+    return sanitize_mcp_env(config.get("env"))
+
+
+# CGNAT 共有アドレス空間 100.64.0.0/10（RFC 6598）。
+# Python 3.13 の ipaddress.is_private は CGNAT を
+# 含まないため（TS 実装 isBlockedIpv4Octets は 100.64-127 を明示ブロック）、ここで
+# 明示的に判定して TS と網羅性を揃える。クラウド内部サービス（VPC エンドポイント・
+# 内部 LB 等）が CGNAT を使う環境への SSRF を防ぐ。
+_CGNAT_NETWORK = ipaddress.IPv4Network("100.64.0.0/10")
+
+
+def _classify_blocked(addr) -> bool:
+    """ipaddress オブジェクトに対する内部/危険レンジ判定。"""
+    if (
+        addr.is_loopback
+        or addr.is_link_local  # 169.254.0.0/16, fe80::/10（IMDS を含む）
+        or addr.is_private  # 10/8, 172.16/12, 192.168/16, fc00::/7
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    ):
+        return True
+    # CGNAT 100.64.0.0/10 を明示ブロック（TS の isBlockedIpv4Octets と一致）。
+    if isinstance(addr, ipaddress.IPv4Address) and addr in _CGNAT_NETWORK:
+        return True
+    return False
+
+
+def _is_blocked_ip(ip: str) -> bool:
+    """内部 / 危険な IP かどうかを判定する。TS 側 isBlockedIp と一致。
+
+    IPv4-mapped に加え、6to4 (2002::/16) と
+    NAT64 well-known (64:ff9b::/96) の埋め込み IPv4 も取り出して再帰判定し、TS と網羅性を揃える。
+    """
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        # IP として解釈できない値は安全側で拒否（フェイルクローズ）。
+        return True
+
+    if isinstance(addr, ipaddress.IPv6Address):
+        # IPv4-mapped ::ffff:0:0/96
+        if addr.ipv4_mapped:
+            return _classify_blocked(addr.ipv4_mapped)
+        # 6to4 2002::/16
+        if addr.sixtofour:
+            return _classify_blocked(addr.sixtofour)
+        # NAT64 well-known 64:ff9b::/96 → 末尾 32bit を IPv4 として判定
+        if addr in ipaddress.IPv6Network("64:ff9b::/96"):
+            embedded = ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF)
+            return _classify_blocked(embedded)
+
+    return _classify_blocked(addr)
+
+
+def resolve_and_validate_mcp_url(raw_url: str) -> Tuple[str, List[str]]:
+    """MCP HTTP トランスポートの接続先 URL を検証し、(hostname, 安全なIPリスト) を返す。
+
+    MCP HTTP は「検証→接続」の2段階で、両者が独立に
+    DNS を解決するため TOCTOU(DNS rebinding)が成立しうる（検証時に解決した IP と接続時に
+    解決される IP が異なり、169.254.169.254 等の内部へすり替えられる）。本関数は検証時に
+    解決した『安全と確認できた IP』を呼び出し側へ返し、呼び出し側がその IP をピン留めして
+    接続することで、解決先のすり替え窓を閉じる。
+
+    - スキームが http/https 以外なら拒否。
+    - ホストが localhost / 内部 IP リテラルなら拒否。
+    - IP リテラル時は解決を伴わない（TOCTOU 無し）ため [hostname] を返す（挙動不変）。
+    - ホスト名は DNS 解決し、解決された全 IP が内部レンジでないことを確認する。安全な IP
+      のみを返す。解決不能・安全な IP ゼロ時は拒否（フェイルクローズ）。
+
+    Returns:
+        (hostname, safe_ips): hostname は小文字化したホスト。safe_ips は接続に使える
+        安全な IP のリスト（IP リテラル時はその IP のみ）。
+    """
+    try:
+        parsed = urlparse(raw_url)
+    except Exception:
+        raise ValueError(f"Invalid MCP URL: {raw_url}")
+
+    if parsed.scheme not in _ALLOWED_URL_SCHEMES:
+        raise ValueError(
+            f"MCP URL scheme not allowed: {parsed.scheme} (only http/https)"
+        )
+
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        raise ValueError(f"MCP URL has no host (fail-closed): {raw_url}")
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        raise ValueError("MCP URL must not target localhost")
+
+    # ホストが IP リテラルならそのまま判定。
+    try:
+        ipaddress.ip_address(hostname)
+        is_ip_literal = True
+    except ValueError:
+        is_ip_literal = False
+
+    if is_ip_literal:
+        if _is_blocked_ip(hostname):
+            raise ValueError(
+                f"MCP URL targets a blocked (internal/loopback/link-local) "
+                f"address: {hostname}"
+            )
+        # IP リテラルは解決が無く TOCTOU 無し。そのまま接続先として返す。
+        return hostname, [hostname]
+
+    # ホスト名は DNS 解決して全 IP を検証する（解決不能ならフェイルクローズ）。
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except Exception:
+        raise ValueError(
+            f"MCP URL host could not be resolved (fail-closed): {hostname}"
+        )
+    addresses: List[str] = []
+    for info in infos:
+        sockaddr = info[4]
+        if sockaddr and len(sockaddr) >= 1:
+            addresses.append(sockaddr[0])
+    if not addresses:
+        raise ValueError(
+            f"MCP URL host resolved to no addresses (fail-closed): {hostname}"
+        )
+    # 解決された全 IP が安全でなければ拒否する（従来挙動）。
+    # 加えて、安全と確認できた IP のみを safe_ips として返し、接続時のピン留めに使う。
+    safe_ips: List[str] = []
+    for address in addresses:
+        if _is_blocked_ip(address):
+            raise ValueError(
+                f"MCP URL host {hostname} resolves to a blocked address: {address}"
+            )
+        safe_ips.append(address)
+    if not safe_ips:
+        # 上の for で全件 raise されるため通常到達しないが、防御的にフェイルクローズ。
+        raise ValueError(
+            f"MCP URL host resolved to no safe addresses (fail-closed): {hostname}"
+        )
+    return hostname, safe_ips
+
+
+def assert_safe_mcp_url(raw_url: str) -> None:
+    """MCP HTTP トランスポートの接続先 URL を検証する。
+
+    後方互換のための薄いラッパ。検証ロジックは resolve_and_validate_mcp_url に集約し、
+    本関数は戻り値（安全な IP）を捨てて副作用（検証）のみを行う。既存の呼び出し側・
+    既存テストの互換を維持する。
+    """
+    resolve_and_validate_mcp_url(raw_url)
+
+
+def create_no_redirect_mcp_http_client(
+    headers=None,
+    timeout=None,
+    auth=None,
+):
+    """MCP HTTP トランスポート用の httpx クライアント。
+    mcp SDK 既定の create_mcp_http_client は follow_redirects=True を常時設定するため、
+    接続前 URL 検証(assert_safe_mcp_url)を通過後に 3xx で内部(IMDS/VPC)へ誘導される
+    SSRF が成立する。本ファクトリは follow_redirects=False を強制する(フェイルクローズ)。
+    mcp の McpHttpClientFactory Protocol(headers/timeout/auth)と同一シグネチャ。
+    """
+    kwargs = {"follow_redirects": False}
+    kwargs["timeout"] = timeout if timeout is not None else httpx.Timeout(30.0)
+    if headers is not None:
+        kwargs["headers"] = headers
+    if auth is not None:
+        kwargs["auth"] = auth
+    return httpx.AsyncClient(**kwargs)
+
+
+class _PinnedAsyncHTTPTransport(httpx.AsyncHTTPTransport):
+    """検証済み IP へ接続先を固定する httpx トランスポート。
+
+    MCP HTTP の「検証→接続」2段階は両者が独立に DNS 解決するため、検証通過後・接続前に
+    攻撃者が DNS を rebind すると内部(IMDS 169.254.169.254 / VPC)へすり替えられる
+    （TOCTOU / DNS rebinding）。本トランスポートは検証時に安全と確認した IP を接続先へ
+    固定し、すり替え窓を閉じる。
+
+    HTTPS の証明書検証を壊さないため、IP に直結しつつ TLS は元ホスト名で検証する:
+      - request.url.host = pinned_ip      接続先を固定 IP に
+      - Host ヘッダ       = original_host  仮想ホスト・サーバ側ルーティングを維持
+      - extensions['sni_hostname'] = original_host  SNI と証明書検証を元ホスト名で実施
+    """
+
+    def __init__(self, pinned_ip: str, original_host: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._pinned_ip = pinned_ip
+        self._original_host = original_host
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        # 接続先 IP を固定（元ホスト名は Host/SNI で維持）。
+        request.url = request.url.copy_with(host=self._pinned_ip)
+        # Host ヘッダを元ホスト名へ（IP 直結でも仮想ホストが解決されるように）。
+        request.headers["Host"] = self._original_host
+        # TLS の SNI と証明書検証を元ホスト名で行う（IP 直結でも証明書検証を維持）。
+        request.extensions = dict(request.extensions or {})
+        request.extensions["sni_hostname"] = self._original_host
+        return await super().handle_async_request(request)
+
+
+def create_pinned_mcp_http_client_factory(pinned_ip: str, original_host: str):
+    """検証済み IP をピン留めする McpHttpClientFactory を返す。
+
+    mcp の McpHttpClientFactory Protocol(headers/timeout/auth)と同一シグネチャの factory を返す。
+    生成されるクライアントは:
+      - follow_redirects=False を維持（リダイレクト無効化を併存）。
+      - _PinnedAsyncHTTPTransport により接続先 IP を pinned_ip に固定（DNS rebinding 緩和）。
+        TLS/SNI/Host は original_host を維持するため証明書検証は壊れない。
+    """
+
+    def factory(headers=None, timeout=None, auth=None) -> httpx.AsyncClient:
+        transport = _PinnedAsyncHTTPTransport(
+            pinned_ip=pinned_ip, original_host=original_host
+        )
+        kwargs: Dict[str, Any] = {
+            "follow_redirects": False,
+            "transport": transport,
+        }
+        kwargs["timeout"] = timeout if timeout is not None else httpx.Timeout(30.0)
+        if headers is not None:
+            kwargs["headers"] = headers
+        if auth is not None:
+            kwargs["auth"] = auth
+        return httpx.AsyncClient(**kwargs)
+
+    return factory
+
+
+# ログ出力用に MCP サーバ設定の機微情報をマスクする。
+# backend/.../tool-configuration.ts の maskToolConfiguration / maskUrlSecrets をミラー。
+_REDACTED = "***REDACTED***"
+
+
+def _mask_url_secrets(raw: str) -> str:
+    """URL の userinfo・クエリ値をマスク。パース不能なら ? 以降を落とす（防御的）。"""
+    try:
+        parsed = urlparse(raw)
+        netloc = parsed.hostname or ""
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
+        masked_query = ""
+        if parsed.query:
+            pairs = parse_qsl(parsed.query, keep_blank_values=True)
+            masked_query = urlencode([(k, _REDACTED) for k, _ in pairs])
+        return urlunparse((
+            parsed.scheme, netloc, parsed.path,
+            parsed.params, masked_query, parsed.fragment,
+        ))
+    except Exception:
+        idx = raw.find("?")
+        return raw[:idx] if idx >= 0 else raw
+
+
+def mask_mcp_server_config(cfg: Any) -> Any:
+    """単一 MCP サーバ設定のクローンを返し headers/env のキー値・args 各要素・url 秘密をマスク。
+    形状が想定外でも例外を投げず可能な範囲でマスクして返す（防御的・ログ専用）。"""
+    if not isinstance(cfg, dict):
+        return cfg
+    masked = dict(cfg)
+    if isinstance(masked.get("headers"), dict):
+        masked["headers"] = {k: _REDACTED for k in masked["headers"].keys()}
+    if isinstance(masked.get("env"), dict):
+        masked["env"] = {k: _REDACTED for k in masked["env"].keys()}
+    if isinstance(masked.get("args"), list):
+        masked["args"] = [_REDACTED for _ in masked["args"]]
+    if isinstance(masked.get("url"), str) and masked["url"]:
+        masked["url"] = _mask_url_secrets(masked["url"])
+    return masked

--- a/review-item-processor/uv.lock
+++ b/review-item-processor/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.4"
+version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -24,59 +24,72 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/4a/064321452809dae953c1ed6e017504e72551a26b6f5708a5a80e4bf556ff/aiohttp-3.13.4.tar.gz", hash = "sha256:d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38", size = 7859748, upload-time = "2026-03-28T17:19:40.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/ac/892f4162df9b115b4758d615f32ec63d00f3084c705ff5526630887b9b42/aiohttp-3.13.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:63dd5e5b1e43b8fb1e91b79b7ceba1feba588b317d1edff385084fcc7a0a4538", size = 745744, upload-time = "2026-03-28T17:16:44.67Z" },
-    { url = "https://files.pythonhosted.org/packages/97/a9/c5b87e4443a2f0ea88cb3000c93a8fdad1ee63bffc9ded8d8c8e0d66efc6/aiohttp-3.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:746ac3cc00b5baea424dacddea3ec2c2702f9590de27d837aa67004db1eebc6e", size = 498178, upload-time = "2026-03-28T17:16:46.766Z" },
-    { url = "https://files.pythonhosted.org/packages/94/42/07e1b543a61250783650df13da8ddcdc0d0a5538b2bd15cef6e042aefc61/aiohttp-3.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bda8f16ea99d6a6705e5946732e48487a448be874e54a4f73d514660ff7c05d3", size = 498331, upload-time = "2026-03-28T17:16:48.9Z" },
-    { url = "https://files.pythonhosted.org/packages/20/d6/492f46bf0328534124772d0cf58570acae5b286ea25006900650f69dae0e/aiohttp-3.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b061e7b5f840391e3f64d0ddf672973e45c4cfff7a0feea425ea24e51530fc2", size = 1744414, upload-time = "2026-03-28T17:16:50.968Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/4d/e02627b2683f68051246215d2d62b2d2f249ff7a285e7a858dc47d6b6a14/aiohttp-3.13.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b252e8d5cd66184b570d0d010de742736e8a4fab22c58299772b0c5a466d4b21", size = 1719226, upload-time = "2026-03-28T17:16:53.173Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/6c/5d0a3394dd2b9f9aeba6e1b6065d0439e4b75d41f1fb09a3ec010b43552b/aiohttp-3.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20af8aad61d1803ff11152a26146d8d81c266aa8c5aa9b4504432abb965c36a0", size = 1782110, upload-time = "2026-03-28T17:16:55.362Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/2d/c20791e3437700a7441a7edfb59731150322424f5aadf635602d1d326101/aiohttp-3.13.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:13a5cc924b59859ad2adb1478e31f410a7ed46e92a2a619d6d1dd1a63c1a855e", size = 1884809, upload-time = "2026-03-28T17:16:57.734Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/94/d99dbfbd1924a87ef643833932eb2a3d9e5eee87656efea7d78058539eff/aiohttp-3.13.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:534913dfb0a644d537aebb4123e7d466d94e3be5549205e6a31f72368980a81a", size = 1764938, upload-time = "2026-03-28T17:17:00.221Z" },
-    { url = "https://files.pythonhosted.org/packages/49/61/3ce326a1538781deb89f6cf5e094e2029cd308ed1e21b2ba2278b08426f6/aiohttp-3.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:320e40192a2dcc1cf4b5576936e9652981ab596bf81eb309535db7e2f5b5672f", size = 1570697, upload-time = "2026-03-28T17:17:02.985Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/77/4ab5a546857bb3028fbaf34d6eea180267bdab022ee8b1168b1fcde4bfdd/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9e587fcfce2bcf06526a43cb705bdee21ac089096f2e271d75de9c339db3100c", size = 1702258, upload-time = "2026-03-28T17:17:05.28Z" },
-    { url = "https://files.pythonhosted.org/packages/79/63/d8f29021e39bc5af8e5d5e9da1b07976fb9846487a784e11e4f4eeda4666/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9eb9c2eea7278206b5c6c1441fdd9dc420c278ead3f3b2cc87f9b693698cc500", size = 1740287, upload-time = "2026-03-28T17:17:07.712Z" },
-    { url = "https://files.pythonhosted.org/packages/55/3a/cbc6b3b124859a11bc8055d3682c26999b393531ef926754a3445b99dfef/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:29be00c51972b04bf9d5c8f2d7f7314f48f96070ca40a873a53056e652e805f7", size = 1753011, upload-time = "2026-03-28T17:17:10.053Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/30/836278675205d58c1368b21520eab9572457cf19afd23759216c04483048/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90c06228a6c3a7c9f776fe4fc0b7ff647fffd3bed93779a6913c804ae00c1073", size = 1566359, upload-time = "2026-03-28T17:17:12.433Z" },
-    { url = "https://files.pythonhosted.org/packages/50/b4/8032cc9b82d17e4277704ba30509eaccb39329dc18d6a35f05e424439e32/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a533ec132f05fd9a1d959e7f34184cd7d5e8511584848dab85faefbaac573069", size = 1785537, upload-time = "2026-03-28T17:17:14.721Z" },
-    { url = "https://files.pythonhosted.org/packages/17/7d/5873e98230bde59f493bf1f7c3e327486a4b5653fa401144704df5d00211/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1c946f10f413836f82ea4cfb90200d2a59578c549f00857e03111cf45ad01ca5", size = 1740752, upload-time = "2026-03-28T17:17:17.387Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/f2/13e46e0df051494d7d3c68b7f72d071f48c384c12716fc294f75d5b1a064/aiohttp-3.13.4-cp313-cp313-win32.whl", hash = "sha256:48708e2706106da6967eff5908c78ca3943f005ed6bcb75da2a7e4da94ef8c70", size = 433187, upload-time = "2026-03-28T17:17:19.523Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/c0/649856ee655a843c8f8664592cfccb73ac80ede6a8c8db33a25d810c12db/aiohttp-3.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:74a2eb058da44fa3a877a49e2095b591d4913308bb424c418b77beb160c55ce3", size = 459778, upload-time = "2026-03-28T17:17:21.964Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/29/6657cc37ae04cacc2dbf53fb730a06b6091cc4cbe745028e047c53e6d840/aiohttp-3.13.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:e0a2c961fc92abeff61d6444f2ce6ad35bb982db9fc8ff8a47455beacf454a57", size = 749363, upload-time = "2026-03-28T17:17:24.044Z" },
-    { url = "https://files.pythonhosted.org/packages/90/7f/30ccdf67ca3d24b610067dc63d64dcb91e5d88e27667811640644aa4a85d/aiohttp-3.13.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:153274535985a0ff2bff1fb6c104ed547cec898a09213d21b0f791a44b14d933", size = 499317, upload-time = "2026-03-28T17:17:26.199Z" },
-    { url = "https://files.pythonhosted.org/packages/93/13/e372dd4e68ad04ee25dafb050c7f98b0d91ea643f7352757e87231102555/aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:351f3171e2458da3d731ce83f9e6b9619e325c45cbd534c7759750cabf453ad7", size = 500477, upload-time = "2026-03-28T17:17:28.279Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/fe/ee6298e8e586096fb6f5eddd31393d8544f33ae0792c71ecbb4c2bef98ac/aiohttp-3.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f989ac8bc5595ff761a5ccd32bdb0768a117f36dd1504b1c2c074ed5d3f4df9c", size = 1737227, upload-time = "2026-03-28T17:17:30.587Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/b9/a7a0463a09e1a3fe35100f74324f23644bfc3383ac5fd5effe0722a5f0b7/aiohttp-3.13.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d36fc1709110ec1e87a229b201dd3ddc32aa01e98e7868083a794609b081c349", size = 1694036, upload-time = "2026-03-28T17:17:33.29Z" },
-    { url = "https://files.pythonhosted.org/packages/57/7c/8972ae3fb7be00a91aee6b644b2a6a909aedb2c425269a3bfd90115e6f8f/aiohttp-3.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:42adaeea83cbdf069ab94f5103ce0787c21fb1a0153270da76b59d5578302329", size = 1786814, upload-time = "2026-03-28T17:17:36.035Z" },
-    { url = "https://files.pythonhosted.org/packages/93/01/c81e97e85c774decbaf0d577de7d848934e8166a3a14ad9f8aa5be329d28/aiohttp-3.13.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:92deb95469928cc41fd4b42a95d8012fa6df93f6b1c0a83af0ffbc4a5e218cde", size = 1866676, upload-time = "2026-03-28T17:17:38.441Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/5f/5b46fe8694a639ddea2cd035bf5729e4677ea882cb251396637e2ef1590d/aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c0c7c07c4257ef3a1df355f840bc62d133bcdef5c1c5ba75add3c08553e2eed", size = 1740842, upload-time = "2026-03-28T17:17:40.783Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a2/0d4b03d011cca6b6b0acba8433193c1e484efa8d705ea58295590fe24203/aiohttp-3.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f062c45de8a1098cb137a1898819796a2491aec4e637a06b03f149315dff4d8f", size = 1566508, upload-time = "2026-03-28T17:17:43.235Z" },
-    { url = "https://files.pythonhosted.org/packages/98/17/e689fd500da52488ec5f889effd6404dece6a59de301e380f3c64f167beb/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:76093107c531517001114f0ebdb4f46858ce818590363e3e99a4a2280334454a", size = 1700569, upload-time = "2026-03-28T17:17:46.165Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/0d/66402894dbcf470ef7db99449e436105ea862c24f7ea4c95c683e635af35/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:6f6ec32162d293b82f8b63a16edc80769662fbd5ae6fbd4936d3206a2c2cc63b", size = 1707407, upload-time = "2026-03-28T17:17:48.825Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/eb/af0ab1a3650092cbd8e14ef29e4ab0209e1460e1c299996c3f8288b3f1ff/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5903e2db3d202a00ad9f0ec35a122c005e85d90c9836ab4cda628f01edf425e2", size = 1752214, upload-time = "2026-03-28T17:17:51.206Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/bf/72326f8a98e4c666f292f03c385545963cc65e358835d2a7375037a97b57/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2d5bea57be7aca98dbbac8da046d99b5557c5cf4e28538c4c786313078aca09e", size = 1562162, upload-time = "2026-03-28T17:17:53.634Z" },
-    { url = "https://files.pythonhosted.org/packages/67/9f/13b72435f99151dd9a5469c96b3b5f86aa29b7e785ca7f35cf5e538f74c0/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:bcf0c9902085976edc0232b75006ef38f89686901249ce14226b6877f88464fb", size = 1768904, upload-time = "2026-03-28T17:17:55.991Z" },
-    { url = "https://files.pythonhosted.org/packages/18/bc/28d4970e7d5452ac7776cdb5431a1164a0d9cf8bd2fffd67b4fb463aa56d/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3295f98bfeed2e867cab588f2a146a9db37a85e3ae9062abf46ba062bd29165", size = 1723378, upload-time = "2026-03-28T17:17:58.348Z" },
-    { url = "https://files.pythonhosted.org/packages/53/74/b32458ca1a7f34d65bdee7aef2036adbe0438123d3d53e2b083c453c24dd/aiohttp-3.13.4-cp314-cp314-win32.whl", hash = "sha256:a598a5c5767e1369d8f5b08695cab1d8160040f796c4416af76fd773d229b3c9", size = 438711, upload-time = "2026-03-28T17:18:00.728Z" },
-    { url = "https://files.pythonhosted.org/packages/40/b2/54b487316c2df3e03a8f3435e9636f8a81a42a69d942164830d193beb56a/aiohttp-3.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:c555db4bc7a264bead5a7d63d92d41a1122fcd39cc62a4db815f45ad46f9c2c8", size = 464977, upload-time = "2026-03-28T17:18:03.367Z" },
-    { url = "https://files.pythonhosted.org/packages/47/fb/e41b63c6ce71b07a59243bb8f3b457ee0c3402a619acb9d2c0d21ef0e647/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:45abbbf09a129825d13c18c7d3182fecd46d9da3cfc383756145394013604ac1", size = 781549, upload-time = "2026-03-28T17:18:05.779Z" },
-    { url = "https://files.pythonhosted.org/packages/97/53/532b8d28df1e17e44c4d9a9368b78dcb6bf0b51037522136eced13afa9e8/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:74c80b2bc2c2adb7b3d1941b2b60701ee2af8296fc8aad8b8bc48bc25767266c", size = 514383, upload-time = "2026-03-28T17:18:08.096Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/1f/62e5d400603e8468cd635812d99cb81cfdc08127a3dc474c647615f31339/aiohttp-3.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c97989ae40a9746650fa196894f317dafc12227c808c774929dda0ff873a5954", size = 518304, upload-time = "2026-03-28T17:18:10.642Z" },
-    { url = "https://files.pythonhosted.org/packages/90/57/2326b37b10896447e3c6e0cbef4fe2486d30913639a5cfd1332b5d870f82/aiohttp-3.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dae86be9811493f9990ef44fff1685f5c1a3192e9061a71a109d527944eed551", size = 1893433, upload-time = "2026-03-28T17:18:13.121Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b4/a24d82112c304afdb650167ef2fe190957d81cbddac7460bedd245f765aa/aiohttp-3.13.4-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1db491abe852ca2fa6cc48a3341985b0174b3741838e1341b82ac82c8bd9e871", size = 1755901, upload-time = "2026-03-28T17:18:16.21Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/2d/0883ef9d878d7846287f036c162a951968f22aabeef3ac97b0bea6f76d5d/aiohttp-3.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0e5d701c0aad02a7dce72eef6b93226cf3734330f1a31d69ebbf69f33b86666e", size = 1876093, upload-time = "2026-03-28T17:18:18.703Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/52/9204bb59c014869b71971addad6778f005daa72a96eed652c496789d7468/aiohttp-3.13.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ac32a189081ae0a10ba18993f10f338ec94341f0d5df8fff348043962f3c6f8", size = 1970815, upload-time = "2026-03-28T17:18:21.858Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/b5/e4eb20275a866dde0f570f411b36c6b48f7b53edfe4f4071aa1b0728098a/aiohttp-3.13.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98e968cdaba43e45c73c3f306fca418c8009a957733bac85937c9f9cf3f4de27", size = 1816223, upload-time = "2026-03-28T17:18:24.729Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/23/e98075c5bb146aa61a1239ee1ac7714c85e814838d6cebbe37d3fe19214a/aiohttp-3.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca114790c9144c335d538852612d3e43ea0f075288f4849cf4b05d6cd2238ce7", size = 1649145, upload-time = "2026-03-28T17:18:27.269Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c1/7bad8be33bb06c2bb224b6468874346026092762cbec388c3bdb65a368ee/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ea2e071661ba9cfe11eabbc81ac5376eaeb3061f6e72ec4cc86d7cdd1ffbdbbb", size = 1816562, upload-time = "2026-03-28T17:18:29.847Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/10/c00323348695e9a5e316825969c88463dcc24c7e9d443244b8a2c9cf2eae/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:34e89912b6c20e0fd80e07fa401fd218a410aa1ce9f1c2f1dad6db1bd0ce0927", size = 1800333, upload-time = "2026-03-28T17:18:32.269Z" },
-    { url = "https://files.pythonhosted.org/packages/84/43/9b2147a1df3559f49bd723e22905b46a46c068a53adb54abdca32c4de180/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0e217cf9f6a42908c52b46e42c568bd57adc39c9286ced31aaace614b6087965", size = 1820617, upload-time = "2026-03-28T17:18:35.238Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/7f/b3481a81e7a586d02e99387b18c6dafff41285f6efd3daa2124c01f87eae/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:0c296f1221e21ba979f5ac1964c3b78cfde15c5c5f855ffd2caab337e9cd9182", size = 1643417, upload-time = "2026-03-28T17:18:37.949Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/72/07181226bc99ce1124e0f89280f5221a82d3ae6a6d9d1973ce429d48e52b/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d99a9d168ebaffb74f36d011750e490085ac418f4db926cce3989c8fe6cb6b1b", size = 1849286, upload-time = "2026-03-28T17:18:40.534Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/e6/1b3566e103eca6da5be4ae6713e112a053725c584e96574caf117568ffef/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cb19177205d93b881f3f89e6081593676043a6828f59c78c17a0fd6c1fbed2ba", size = 1782635, upload-time = "2026-03-28T17:18:43.073Z" },
-    { url = "https://files.pythonhosted.org/packages/37/58/1b11c71904b8d079eb0c39fe664180dd1e14bebe5608e235d8bfbadc8929/aiohttp-3.13.4-cp314-cp314t-win32.whl", hash = "sha256:c606aa5656dab6552e52ca368e43869c916338346bfaf6304e15c58fb113ea30", size = 472537, upload-time = "2026-03-28T17:18:46.286Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/8f/87c56a1a1977d7dddea5b31e12189665a140fdb48a71e9038ff90bb564ec/aiohttp-3.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:014dcc10ec8ab8db681f0d68e939d1e9286a5aa2b993cbbdb0db130853e02144", size = 506381, upload-time = "2026-03-28T17:18:48.74Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/97/bd137012dd97e1649162b099135a80e1fd59aaa807b2430fc448d1029aff/aiohttp-3.14.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178", size = 506882, upload-time = "2026-06-07T21:07:15.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/79/e5cc690e9d922a66887ceeaca53a8ffd5a7b0be3816142b7abc433742d89/aiohttp-3.14.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf", size = 515270, upload-time = "2026-06-07T21:07:17.53Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
+    { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a1/5fafa04e1ca91ddb47608699d60649c1c6db3cf41c99e78fc4056f9513db/aiohttp-3.14.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:7c106c26852ca1c2047c6b80384f17100b4e439af276f21ef3d4e2f450ae7e15", size = 508531, upload-time = "2026-06-07T21:08:02.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/2e/bfa02f699d87ffc86d5959270b28f1cb410add3ccaced8ed2e0b8a5238fc/aiohttp-3.14.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:20205f7f5ade7aaec9f4b500549bbc071b046453aed72f9c06dcab87896a83e8", size = 514718, upload-time = "2026-06-07T21:08:04.476Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a5/9594ad6289eebbc97d167c44213d557807f90e59115caad24de21ad2c3b1/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:62a759436b29e677181a9e76bab8b8f689a29cb9c535f45f7c48c9c830d3f8c3", size = 487918, upload-time = "2026-06-07T21:08:06.377Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/61/16a32c36c3c49edec122a3dc811f2057df2f94d3b14aa107c8017d981618/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:2964cbf553df4d7a57348da44d961d871895fc1ee4e8c322b2a95612c7b17fba", size = 494014, upload-time = "2026-06-07T21:08:08.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/89/3ebcf96ed99c05bec9c434aaac6963fd3cbab4a786ae739908a144d9ce44/aiohttp-3.14.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:237651caadc3a59badd39319c54642b5299e9cc98a3a194310e55d5bb9f5e397", size = 502398, upload-time = "2026-06-07T21:08:10.244Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3d/b74870a0c2d40c355928cd5b96c7a11fa821b8a40fc41365e64479b151fb/aiohttp-3.14.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:896e12dfdbbab9d8f7e16d2b28c6769a60126fa92095d1ebf9473d02593a2448", size = 758018, upload-time = "2026-06-07T21:08:12.447Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/66/f42f5c984d99e49c6cff5f26f590750f2e2f7ef1fcfb99966ab5be1b632e/aiohttp-3.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d03f281ed22579314ba00821ce20115a7c0ac430660b4cc05704a3f818b3e004", size = 512462, upload-time = "2026-06-07T21:08:14.624Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a7/248e1aebe0c7810b0271e021a0f2a5eb6e78a051885b3c9df49f42a5802d/aiohttp-3.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:07eabb979d236335fed927e137a928c9adfb7df3b9ec7aa31726f133a62be983", size = 512824, upload-time = "2026-06-07T21:08:16.572Z" },
+    { url = "https://files.pythonhosted.org/packages/26/97/2aa0e5ba0727dc3bd5aaebb7ccbc510f7dfb7fb961ec87497cd496635ab1/aiohttp-3.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4fe1f1087cbadb280b5e1bb054a4f00d1423c74d6626c5e48400d871d34ecefe", size = 1749898, upload-time = "2026-06-07T21:08:18.635Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8d/e97f6c96c891d457c8479d92a514ba194d0412f981d72c70341ee18488ed/aiohttp-3.14.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:367a9314fdc79dab0fac96e216cb41dd73c85bdca85306ce8999118ba7e0f333", size = 1710114, upload-time = "2026-06-07T21:08:20.892Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e6/aa8d7e863048c8fceb5cd6ce74017311cec3ead07847387e12265fb4444e/aiohttp-3.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a24f677ebe83749039e7bdf862ff0bbb16818ae4193d4ef96505e269375bcce0", size = 1802541, upload-time = "2026-06-07T21:08:23.044Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a8/72193137de57fda4ebfae4563182d082c8856e3b6e9871d0b46f028fb369/aiohttp-3.14.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c83afe0ba876be7e943d2e0ba645809ad441575d2840c895c21ee5de93b9377a", size = 1875776, upload-time = "2026-06-07T21:08:25.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/18/938441025db6769a3464596b2410af3afde0b21eb2f204c6f766f68af4bd/aiohttp-3.14.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:634e385930fb6d2d479cf3aa66515955863b77a5e3c2b5894ca259a25b308602", size = 1760329, upload-time = "2026-06-07T21:08:27.363Z" },
+    { url = "https://files.pythonhosted.org/packages/60/29/bf2496b4065e76e09fe48015aaffe5ce161d8f089b06ac6982070f653076/aiohttp-3.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eeea07c4397bbc57719c4eed8f9c284874d4f175f9b6d57f7a1546b976d455ca", size = 1587293, upload-time = "2026-06-07T21:08:29.805Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a2/2136674d52123b1354bd05dd5753c318db47dc0c927cc70b27bab3755456/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:335c0cc3e3545ce98dcb9cfcb836f40c3411f43fa03dab757597d80c89af8a35", size = 1714756, upload-time = "2026-06-07T21:08:32.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b9/e5fd2e6f915503081c0f9b1e8540947037929c70c191da2e4d54b31a21a1/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ae6be797afdef264e8a84864a85b196ca06045586481b3df8a967322fd2fa844", size = 1721052, upload-time = "2026-06-07T21:08:34.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5a/2833e324a2263e104e31e2e91bc5bbee81bc499afd32203faee048a883f0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:8560b4d712474335d08907db7973f71912d3a9a8f1dee992ec06b5d2fe359496", size = 1766888, upload-time = "2026-06-07T21:08:36.95Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fa/dea6511870913162f3b2e8c42a7614eb203a4540b8c2da43e0bfb0548f3c/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7edd08e0a5deb1e8564a2fcd8f4561014a3f05252334671bbf55ddd47db0e5", size = 1581679, upload-time = "2026-06-07T21:08:39.292Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bd/3cf0d55e71784b33534e9710a67d382d900598b4787fbce6cc7317f8c42a/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b6ff7fcee63287ae57b5df3e4f5957ce032122802509246dec1a5bcc55904c95", size = 1782021, upload-time = "2026-06-07T21:08:41.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/af/14bb5843eccbe234f4dfb78ab73e549d99727247e62ae5d62cbd22eaf5b0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6ffbb2f4ec1ceaff7e07d43922954da26b223d188bf30658e561b98e23089444", size = 1742574, upload-time = "2026-06-07T21:08:43.795Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1e/fbeb7af9210a67ac0f9c9bec0f8f4568497924e33137a3d5b48e1cf85f3f/aiohttp-3.14.1-cp314-cp314-win32.whl", hash = "sha256:a9875b46d910cff3ea2f5962f9d266b465459fe634e22556ab9bd6fc1192eea0", size = 457773, upload-time = "2026-06-07T21:08:46.168Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/13e8d741a9ec5db7d900c060554cf8352ab85e44e2a4469ebb9d377bda17/aiohttp-3.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:af8b4b81a960eeaf1234971ac3cd0ba5901f3cd42eae42a46b4d089a8b492719", size = 485001, upload-time = "2026-06-07T21:08:48.401Z" },
+    { url = "https://files.pythonhosted.org/packages/df/30/491acfa2c4d6c3ff59c49a14fc1b50be3241e25bbb0c84c09e2da4d11395/aiohttp-3.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:cf4491381b1b57425c315a56a439251b1bdac07b2275f19a8c44bc57744532ec", size = 453809, upload-time = "2026-06-07T21:08:50.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e3/19dbe1a1f4cc6230eb9e314de7fe68053b0992f9302b27d12141a0b5db53/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:819c054312f1af92947e6a55883d1b66feefab11531a7fc45e0fb9b63880b5c2", size = 793320, upload-time = "2026-06-07T21:08:52.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/20/1b7182219ba1b108430d6e4dc53d25ae02dcfcf5a045b33af4e8c5167527/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10ee9c1753a8f706345b22496c79fbddb5be0599e0823f3738b1534058e25340", size = 529077, upload-time = "2026-06-07T21:08:55Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c8/14ce60ec31a2e5f5274bb17d383a6f7a3aabca31ac04eee05585bbadab16/aiohttp-3.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1601cc37baf5750ccacae618ec2daf020769581695550e3b654a911f859c563d", size = 532476, upload-time = "2026-06-07T21:08:57.176Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/02/9ac85e081e53da2e061b02fa7758fe0a12d17b8ce2d1f5e6c7cb76730328/aiohttp-3.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d6e0ac9da31c9c04c84e1c0182ad8d6df35965a85cae29cd71d089621b3ae94", size = 1922347, upload-time = "2026-06-07T21:08:59.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3e/d3ba07a0ab38b5389e10bec4362d21e10a4f667cba2d79ba30837b3a5059/aiohttp-3.14.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e8f2d660c350b3d0e259c7a7e3d9b7fc8b41210cbcc3d4a7076ff0a5e5c2fdc", size = 1786465, upload-time = "2026-06-07T21:09:01.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cb/e2ee978a00cfb2df829704a69528b18154eba5939f45bc1efa8f33aee4c5/aiohttp-3.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4691802dda97be727f79d86818acaad7eb8e9252626a1d6b519fedbb92d5e251", size = 1909423, upload-time = "2026-06-07T21:09:04.357Z" },
+    { url = "https://files.pythonhosted.org/packages/73/5d/1430334858b1022b58ae50399a918f0bd6fe8fa7fa183598d657ff61e040/aiohttp-3.14.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c389c482a7e9b9dc3ee2701ac46c4125297a3818875b9c305ddb603c04828fd1", size = 2001906, upload-time = "2026-06-07T21:09:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4e/560c7472d3d198a23aa5c8b19a5115bf6a9b77b7d3e4bb363da320430ad2/aiohttp-3.14.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc0cacab7ba4e56f0f81c82a98c09bed2f39c940107b03a34b168bdf7597edd3", size = 1877095, upload-time = "2026-06-07T21:09:09.011Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f1/4745806578d447db4a784a8591e2dae3afdfc2bcb96f8f81271b13df6543/aiohttp-3.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:979ed4717f59b8bb12e3963378fa285d93d367e15bcd66c721311826d3c44a6c", size = 1676222, upload-time = "2026-06-07T21:09:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/48255813cca749a229ef0ab476004ec623728ad79a9c0840616f6c076325/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:38e1e7daaea81df51c952e18483f323d878499a1e2bfe564790e0f9701d6f203", size = 1842922, upload-time = "2026-06-07T21:09:14.118Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c0/bbd054e2bee909f529523a5af3891052606af5143c09f5f183ec3b234676/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4132e72c608fe9fecb8f409113567605915b83e9bdd3ea56538d2f9cd35002f1", size = 1825035, upload-time = "2026-06-07T21:09:16.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ae/90395d4376deceb74e09ec26b6adf7d2015a6f8802d6d84446af860fef04/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:eefd9cc9b6d4a2db5f00a26bc3e4f9acf71926a6ec557cd56c9c6f27c290b665", size = 1849512, upload-time = "2026-06-07T21:09:18.742Z" },
+    { url = "https://files.pythonhosted.org/packages/93/bd/fb25f3049957553d4ce0ba6ae480aa2f592a6985497fca590837d16c1be0/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b165790117eea512d7f3fb22f1f6dad3d55a7189571993eb015591c1401276d1", size = 1668571, upload-time = "2026-06-07T21:09:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/7f73303d64dd567ff3addca90b556690ed1233a47b8f55d242fb90af3681/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ed09c7eb1c391271c2ed0314a51903e72a3acb653d5ccfc264cdf3ef11f8269d", size = 1881159, upload-time = "2026-06-07T21:09:23.813Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/0474c5a8b5640e1e4aa1923430a91f4151be82e511373fe764189b89aef5/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:99abd37084b82f5830c635fddd0b4993b9742a66eb746dacf433c8590e8f9e3c", size = 1841409, upload-time = "2026-06-07T21:09:26.207Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
 ]
 
 [[package]]
@@ -224,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "bedrock-agentcore"
-version = "0.1.0"
+version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -234,38 +247,39 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
     { name = "uvicorn" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/67/f07523e943d2e68be3dc2f256b0adb1027da521ad31d5a2caba6f158bd2b/bedrock_agentcore-0.1.0.tar.gz", hash = "sha256:05eea20588e8794cb51b1c76c064fa70d01d0a4bfb404b50e680ddccf10c85d0", size = 269981, upload-time = "2025-07-16T18:32:10.763Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/ff/de9c721ec4dd4cd0e03bf7d1a59c3f7c68273d59ba21884bcff1c0a4f455/bedrock_agentcore-1.18.0.tar.gz", hash = "sha256:ddaea72191632549d2f28faa5f37af3321a14715d7149d841107e9f91a27be96", size = 1030011, upload-time = "2026-07-10T18:24:16.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/ce/30a61ad1e18b5ee7aeaa997cfcd6cb5cbe449cb90d3669e40d458c94b007/bedrock_agentcore-0.1.0-py3-none-any.whl", hash = "sha256:2356661f0ce5012871ac0f22ad3741654e2accb1acdf21b7f78ff19ef278643a", size = 48710, upload-time = "2025-07-16T18:32:09.363Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d4/f7ea8f31084a2abe9aa874ccffe2dbf67a2c39a812598abeb7a8a784df8b/bedrock_agentcore-1.18.0-py3-none-any.whl", hash = "sha256:d1f6b8851b34ab51c0619caef02c0734b5cc0af6ede019673cc2f4dc231971c9", size = 450509, upload-time = "2026-07-10T18:24:14.927Z" },
 ]
 
 [[package]]
 name = "boto3"
-version = "1.40.66"
+version = "1.43.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/95/db1f23bbc5cf1a9b66cb1828a0940305ea300162ae12c55522c738ab6f0e/boto3-1.40.66.tar.gz", hash = "sha256:f2038d9bac5154da7390c29bfd013546ac96609e7ce5a7f3cb6f99412be3f4c0", size = 111564, upload-time = "2025-11-04T20:28:59.274Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/2c/e9a853d4ca66f7ce1bf820674bcd9e6dd1934c27a4c545c67d3b69338d9b/boto3-1.43.49.tar.gz", hash = "sha256:e58e0704805f720b94e40a56588eadd6da05d3693bde78b573116b11ae56710f", size = 112755, upload-time = "2026-07-15T19:32:17.777Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/c2/3097e2492931b8fdcab47217b917c7964dbc8bfce31f89ace49568ed47f8/boto3-1.40.66-py3-none-any.whl", hash = "sha256:ee4fe21c5301cc0e11cc11a53e71e5ddd82d5fae42b10fa8e5403f3aa06434e3", size = 139361, upload-time = "2025-11-04T20:28:57.146Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/08/73efb432f9da880deb91eded8ed41d23f03ec7ac47af9b8ecf884f276876/boto3-1.43.49-py3-none-any.whl", hash = "sha256:2b31ab1a0eb1cee01d0363b8ee5e68b45dff2c8f99e7b53aca11c9f7b591a794", size = 140033, upload-time = "2026-07-15T19:32:16.483Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.40.66"
+version = "1.43.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/f3/5dae6e3b06493f2ac769c6764543b84fa50a8de3fec1e33252271166b394/botocore-1.40.66.tar.gz", hash = "sha256:e49a55ad54426c4ea853a59ff9d8243023a90c935782d4c287e9b3424883c3fa", size = 14411853, upload-time = "2025-11-04T20:28:48.07Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2c/da2832f435371cd6c95b64325f981b3babe71e4aa4a71798b00ce2073100/botocore-1.43.49.tar.gz", hash = "sha256:7de02863c95b8008b1400c92a1a00996f25ad38944c07f7b620949f8798d1fdf", size = 15708260, upload-time = "2026-07-15T19:32:08.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/48/43f9335e28351f35a939dce366a3943296f381ecd4660bd1c8d2bb8f3006/botocore-1.40.66-py3-none-any.whl", hash = "sha256:98d5766e17e72110b1d08ab510a8475a6597c59d9560235e2d28ae1a4b043b92", size = 14076509, upload-time = "2025-11-04T20:28:44.233Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/21/29bf66d513bca978c9506060c44eaf6df3210bd7773bf94beaed1ce56d18/botocore-1.43.49-py3-none-any.whl", hash = "sha256:16b6838ac2fbbab85fb265c1f2e37906527aca07f461b1d293d3f8ab82f992dc", size = 15393460, upload-time = "2026-07-15T19:32:05.355Z" },
 ]
 
 [[package]]
@@ -386,55 +400,52 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.6"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759", size = 750542, upload-time = "2026-03-25T23:34:53.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8", size = 7176401, upload-time = "2026-03-25T23:33:22.096Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f8/e61f8f13950ab6195b31913b42d39f0f9afc7d93f76710f299b5ec286ae6/cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30", size = 4275275, upload-time = "2026-03-25T23:33:23.844Z" },
-    { url = "https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a", size = 4425320, upload-time = "2026-03-25T23:33:25.703Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175", size = 4278082, upload-time = "2026-03-25T23:33:27.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/ba/d5e27f8d68c24951b0a484924a84c7cdaed7502bac9f18601cd357f8b1d2/cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463", size = 4926514, upload-time = "2026-03-25T23:33:29.206Z" },
-    { url = "https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97", size = 4457766, upload-time = "2026-03-25T23:33:30.834Z" },
-    { url = "https://files.pythonhosted.org/packages/01/59/562be1e653accee4fdad92c7a2e88fced26b3fdfce144047519bbebc299e/cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c", size = 3986535, upload-time = "2026-03-25T23:33:33.02Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/8b/b1ebfeb788bf4624d36e45ed2662b8bd43a05ff62157093c1539c1288a18/cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507", size = 4277618, upload-time = "2026-03-25T23:33:34.567Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/52/a005f8eabdb28df57c20f84c44d397a755782d6ff6d455f05baa2785bd91/cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19", size = 4890802, upload-time = "2026-03-25T23:33:37.034Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/4d/8e7d7245c79c617d08724e2efa397737715ca0ec830ecb3c91e547302555/cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738", size = 4457425, upload-time = "2026-03-25T23:33:38.904Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/5c/f6c3596a1430cec6f949085f0e1a970638d76f81c3ea56d93d564d04c340/cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c", size = 4405530, upload-time = "2026-03-25T23:33:40.842Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/c9/9f9cea13ee2dbde070424e0c4f621c091a91ffcc504ffea5e74f0e1daeff/cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f", size = 4667896, upload-time = "2026-03-25T23:33:42.781Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/b5/1895bc0821226f129bc74d00eccfc6a5969e2028f8617c09790bf89c185e/cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2", size = 3026348, upload-time = "2026-03-25T23:33:45.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124", size = 3483896, upload-time = "2026-03-25T23:33:46.649Z" },
-    { url = "https://files.pythonhosted.org/packages/01/41/3a578f7fd5c70611c0aacba52cd13cb364a5dee895a5c1d467208a9380b0/cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275", size = 7117147, upload-time = "2026-03-25T23:33:48.249Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/87/887f35a6fca9dde90cad08e0de0c89263a8e59b2d2ff904fd9fcd8025b6f/cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4", size = 4266221, upload-time = "2026-03-25T23:33:49.874Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/a8/0a90c4f0b0871e0e3d1ed126aed101328a8a57fd9fd17f00fb67e82a51ca/cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b", size = 4408952, upload-time = "2026-03-25T23:33:52.128Z" },
-    { url = "https://files.pythonhosted.org/packages/16/0b/b239701eb946523e4e9f329336e4ff32b1247e109cbab32d1a7b61da8ed7/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707", size = 4270141, upload-time = "2026-03-25T23:33:54.11Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/a8/976acdd4f0f30df7b25605f4b9d3d89295351665c2091d18224f7ad5cdbf/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361", size = 4904178, upload-time = "2026-03-25T23:33:55.725Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/1b/bf0e01a88efd0e59679b69f42d4afd5bced8700bb5e80617b2d63a3741af/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b", size = 4441812, upload-time = "2026-03-25T23:33:57.364Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/8b/11df86de2ea389c65aa1806f331cae145f2ed18011f30234cc10ca253de8/cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca", size = 3963923, upload-time = "2026-03-25T23:33:59.361Z" },
-    { url = "https://files.pythonhosted.org/packages/91/e0/207fb177c3a9ef6a8108f234208c3e9e76a6aa8cf20d51932916bd43bda0/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013", size = 4269695, upload-time = "2026-03-25T23:34:00.909Z" },
-    { url = "https://files.pythonhosted.org/packages/21/5e/19f3260ed1e95bced52ace7501fabcd266df67077eeb382b79c81729d2d3/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4", size = 4869785, upload-time = "2026-03-25T23:34:02.796Z" },
-    { url = "https://files.pythonhosted.org/packages/10/38/cd7864d79aa1d92ef6f1a584281433419b955ad5a5ba8d1eb6c872165bcb/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a", size = 4441404, upload-time = "2026-03-25T23:34:04.35Z" },
-    { url = "https://files.pythonhosted.org/packages/09/0a/4fe7a8d25fed74419f91835cf5829ade6408fd1963c9eae9c4bce390ecbb/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d", size = 4397549, upload-time = "2026-03-25T23:34:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/a0/7d738944eac6513cd60a8da98b65951f4a3b279b93479a7e8926d9cd730b/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736", size = 4651874, upload-time = "2026-03-25T23:34:07.916Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/f1/c2326781ca05208845efca38bf714f76939ae446cd492d7613808badedf1/cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed", size = 3001511, upload-time = "2026-03-25T23:34:09.892Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/57/fe4a23eb549ac9d903bd4698ffda13383808ef0876cc912bcb2838799ece/cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4", size = 3471692, upload-time = "2026-03-25T23:34:11.613Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/cc/f330e982852403da79008552de9906804568ae9230da8432f7496ce02b71/cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a", size = 7162776, upload-time = "2026-03-25T23:34:13.308Z" },
-    { url = "https://files.pythonhosted.org/packages/49/b3/dc27efd8dcc4bff583b3f01d4a3943cd8b5821777a58b3a6a5f054d61b79/cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8", size = 4270529, upload-time = "2026-03-25T23:34:15.019Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/05/e8d0e6eb4f0d83365b3cb0e00eb3c484f7348db0266652ccd84632a3d58d/cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77", size = 4414827, upload-time = "2026-03-25T23:34:16.604Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/97/daba0f5d2dc6d855e2dcb70733c812558a7977a55dd4a6722756628c44d1/cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290", size = 4271265, upload-time = "2026-03-25T23:34:18.586Z" },
-    { url = "https://files.pythonhosted.org/packages/89/06/fe1fce39a37ac452e58d04b43b0855261dac320a2ebf8f5260dd55b201a9/cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410", size = 4916800, upload-time = "2026-03-25T23:34:20.561Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/8a/b14f3101fe9c3592603339eb5d94046c3ce5f7fc76d6512a2d40efd9724e/cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d", size = 4448771, upload-time = "2026-03-25T23:34:22.406Z" },
-    { url = "https://files.pythonhosted.org/packages/01/b3/0796998056a66d1973fd52ee89dc1bb3b6581960a91ad4ac705f182d398f/cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70", size = 3978333, upload-time = "2026-03-25T23:34:24.281Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3d/db200af5a4ffd08918cd55c08399dc6c9c50b0bc72c00a3246e099d3a849/cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d", size = 4271069, upload-time = "2026-03-25T23:34:25.895Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/18/61acfd5b414309d74ee838be321c636fe71815436f53c9f0334bf19064fa/cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa", size = 4878358, upload-time = "2026-03-25T23:34:27.67Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/65/5bf43286d566f8171917cae23ac6add941654ccf085d739195a4eacf1674/cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58", size = 4448061, upload-time = "2026-03-25T23:34:29.375Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/25/7e49c0fa7205cf3597e525d156a6bce5b5c9de1fd7e8cb01120e459f205a/cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb", size = 4399103, upload-time = "2026-03-25T23:34:32.036Z" },
-    { url = "https://files.pythonhosted.org/packages/44/46/466269e833f1c4718d6cd496ffe20c56c9c8d013486ff66b4f69c302a68d/cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72", size = 4659255, upload-time = "2026-03-25T23:34:33.679Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/09/ddc5f630cc32287d2c953fc5d32705e63ec73e37308e5120955316f53827/cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c", size = 3010660, upload-time = "2026-03-25T23:34:35.418Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/82/ca4893968aeb2709aacfb57a30dec6fa2ab25b10fa9f064b8882ce33f599/cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f", size = 3471160, upload-time = "2026-03-25T23:34:37.191Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -631,11 +642,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2103,11 +2114,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a8/10/e8192be5f38f3e8e7e046716de4cae33d56fd5ae08927a823bb916be36c1/pyjwt-2.12.0.tar.gz", hash = "sha256:2f62390b667cd8257de560b850bb5a883102a388829274147f1d724453f8fb02", size = 102511, upload-time = "2026-03-12T17:15:30.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/70/70f895f404d363d291dcf62c12c85fdd47619ad9674ac0f53364d035925a/pyjwt-2.12.0-py3-none-any.whl", hash = "sha256:9bb459d1bdd0387967d287f5656bf7ec2b9a26645d1961628cda1764e087fd6e", size = 29700, upload-time = "2026-03-12T17:15:29.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -2145,20 +2156,20 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -2273,7 +2284,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
     { name = "strands-agents" },
-    { name = "strands-agents-tools", extra = ["agent-core-code-interpreter"] },
+    { name = "strands-agents-tools" },
 ]
 
 [package.optional-dependencies]
@@ -2293,7 +2304,7 @@ evals = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "aws-opentelemetry-distro", specifier = ">=0.12.2" },
-    { name = "bedrock-agentcore", specifier = "==0.1.0" },
+    { name = "bedrock-agentcore", specifier = "==1.18.0" },
     { name = "boto3", specifier = ">=1.40.22" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "numpy", marker = "extra == 'evals'", specifier = ">=1.26.0" },
@@ -2303,9 +2314,9 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "reportlab", marker = "extra == 'evals'", specifier = ">=4.4.9" },
     { name = "scikit-learn", marker = "extra == 'evals'", specifier = ">=1.3.0" },
-    { name = "strands-agents", specifier = ">=1.30.0" },
+    { name = "strands-agents", specifier = ">=1.52.0" },
     { name = "strands-agents-evals", marker = "extra == 'evals'", specifier = ">=0.1.2" },
-    { name = "strands-agents-tools", extras = ["agent-core-code-interpreter"], specifier = ">=0.2.14" },
+    { name = "strands-agents-tools", specifier = ">=0.2.14" },
     { name = "tabulate", marker = "extra == 'evals'", specifier = ">=0.9.0" },
 ]
 provides-extras = ["dev", "evals"]
@@ -2391,14 +2402,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.14.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
 ]
 
 [[package]]
@@ -2552,14 +2563,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.49.3"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", size = 2655031, upload-time = "2025-11-01T15:12:26.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/e0/021c772d6a662f43b63044ab481dc6ac7592447605b5b35a957785363122/starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f", size = 74340, upload-time = "2025-11-01T15:12:24.387Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -2634,11 +2645,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/c1/17a99b1b9bc94651752b5781b81e96cd6efc39f089410696edfdedade3f7/strands_agents_tools-0.2.14-py3-none-any.whl", hash = "sha256:7b44fa62c0e81b0353b52c23f01c5d0d487034ae6caadbd8d9138d35008147e8", size = 300480, upload-time = "2025-11-04T18:40:34.853Z" },
 ]
 
-[package.optional-dependencies]
-agent-core-code-interpreter = [
-    { name = "bedrock-agentcore" },
-]
-
 [[package]]
 name = "sympy"
 version = "1.14.0"
@@ -2710,11 +2716,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -2758,6 +2764,66 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/02/b9a097e1e16fee4e2fd1ec8c39f6a9c5d6257bae8fa12640caf869f54436/websockets-16.1.tar.gz", hash = "sha256:299468cbe42e2b9981134c7c51d99387d8a7bf562b00183b3eec53f882846dad", size = 182530, upload-time = "2026-07-10T06:32:57.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/63/df158b155420b566f025e75613424ad9649a24bcb0e9f259321ab3d58bea/websockets-16.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b0232ed141cec3df2af5a3959a071c51f40036336b0d37e17faf9ef52fc73e47", size = 179791, upload-time = "2026-07-10T06:31:33.108Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/00fe9414dfeafa6fe54eae9f5716c8c8e9ac59d192be3b893c096d395846/websockets-16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a71b73d143991714144e159f767b698f03c4a70b8a65ae1733b650cff488045b", size = 177472, upload-time = "2026-07-10T06:31:34.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/76/b10633424d40681b4e892ffd08ca5226322b2426e62d4ab71eae484c3a32/websockets-16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:187323204c3b2fc465e8fc2609e60437c521790cb9c1acb49c4c452a33e57f37", size = 177737, upload-time = "2026-07-10T06:31:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/d3bb03b2229bb1afd72008742d586cf1ea240dce64dd48c71c8c7fd3294c/websockets-16.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dba74233c8c3ce368850818c98354dad2570f57231b3fd3bd00d7aa57628881", size = 187403, upload-time = "2026-07-10T06:31:37.496Z" },
+    { url = "https://files.pythonhosted.org/packages/26/16/cc2e80478f688fc3c39c67dc1fac6a0783858058914ebc2489917462cb42/websockets-16.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63339bc8c63c86a463177775cb7c677691f5bcfac7b3b2f01b286d42acd41600", size = 188639, upload-time = "2026-07-10T06:31:38.86Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d6/ad87b2507e57de1cbf897a56c963f2925962ed5e85fbe06aaa83ced27acd/websockets-16.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23e545ea8ae4263e37cdfd4e22a217f519e48e432728bc461185bbf585f38a83", size = 190078, upload-time = "2026-07-10T06:31:40.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1a/5b37b3fd335d5811f29fc829f2646a3e6d1463a4bf09c3100708684c766e/websockets-16.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2237081454846fb40403a80ba86d82e2038b9c45865ab96af0abe7d002a91045", size = 189267, upload-time = "2026-07-10T06:31:41.523Z" },
+    { url = "https://files.pythonhosted.org/packages/42/98/06afc33e9450d4230f94c664db78875d90f5f6a5fb77f0bc6ec15ae74e1c/websockets-16.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f5218de1ed047385ca53744caba9435d65f75d008364970a3fae95a05812cf9", size = 188022, upload-time = "2026-07-10T06:31:42.838Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/42fef5d5887c18cf2d148b02debf56cecb9cfbffc68027cde9b12c8f432c/websockets-16.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75c98e3920039d0edff03b74478ada504b7ce3a1bc406db2cabfca84320f7baf", size = 185435, upload-time = "2026-07-10T06:31:44.219Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9b/8021c133add5fe40ed40312553a6cd1408c069d7efe3444ad483d4973ed3/websockets-16.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1facd189d8190af30487a55b4c3688484dd50801628a3b5b2ccd26db08e67057", size = 188080, upload-time = "2026-07-10T06:31:45.986Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/1e37384f395eaa127383aab15c1c45e200890a7d7b99db5c312233d193e0/websockets-16.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cc0c6a6eef613c7da32d4fb068f82ef834b58134f6a16b54e6c1e5bf9529ab3d", size = 186678, upload-time = "2026-07-10T06:31:47.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/79/1caeacab5bc2081e4519288d248bc8bd2de30652e6eaa94be6be09a1fe5b/websockets-16.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ad9411eded8988b879be6038206698bf7106c85a78f642c004485bcb95be17eb", size = 188554, upload-time = "2026-07-10T06:31:48.886Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/83/b3dca5fad71487b726e31cb0acf56f226792c1cc34e6ab18cbf146bd2d74/websockets-16.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cd68f0914f3b64694895bc5e9b14e8b447e41d7bf5ffaf989bb8dcb5e2dfdce7", size = 186109, upload-time = "2026-07-10T06:31:50.508Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0b/8f246c3712f07f207b52ea5fb47f3b2b66fafec7303162644c74aed51c6a/websockets-16.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fef2debfe7f7ebdda12176f26166f95b7af17af05ba06150fcf889032e0213e9", size = 187061, upload-time = "2026-07-10T06:31:51.861Z" },
+    { url = "https://files.pythonhosted.org/packages/47/eb/27d6c92a01696b6495386af4fc941d7d0a13f2eab2bf9c336111d7321491/websockets-16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3cd6c9b798218798f4bb7b2e71c38f0e744bb94ca537b13376f88019d46384d", size = 187347, upload-time = "2026-07-10T06:31:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d5/eeee439921f55d5eaeabcea18d0f7ce32cdc39cb8fc1e185431a094c5c7b/websockets-16.1-cp313-cp313-win32.whl", hash = "sha256:84c170c6869633536921e4474b1cce7254c0c9b0053ef5725f966cee47e718e4", size = 180149, upload-time = "2026-07-10T06:31:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/971e98d4a4864cf263f9e94c5b2b7c9a9b7682d77bfbba4e732c55ee85a9/websockets-16.1-cp313-cp313-win_amd64.whl", hash = "sha256:bef52d327d70fa75dad93ee61ea2cb1d1489aca9f35c188833563f5a3b4df0a5", size = 180458, upload-time = "2026-07-10T06:31:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e6/da1dc11507f8118145a81c751fe0c77e5e1c11b8554496addb39389e2dc2/websockets-16.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f881fca0a45dd6789939bd6637cd98169b92f1c3fdc78262f2cb9ec2cb1f324e", size = 179833, upload-time = "2026-07-10T06:31:58.19Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ac/c0d46f62e31e232487b2c123bc3cfd9a4e45684ca7dc0c37f0987f29baae/websockets-16.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c379d5b207d3a7f0ba4c2e4602a895b0bcc63fb5f5371a4ae7fbddb03b672b", size = 177524, upload-time = "2026-07-10T06:31:59.563Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/33/abd966074b34a51e4f134e0aaed80f5a4a0a35163ea5ac58a1bc5a076d23/websockets-16.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98ab58a4faa72b46da0127ccc1931dcbfc0985b0778892300a092185910c4cbe", size = 177743, upload-time = "2026-07-10T06:32:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/30/646e47b8a8dff04e227bdab512e6dde60663a647eeac7bbd6edddd92bbc5/websockets-16.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e9c4e369fc181b2d41a99e01477215cecdc8546a39f7d41a59cc0a7065a0b09", size = 187474, upload-time = "2026-07-10T06:32:02.54Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/72/890ab9d77494af93ea65268230bfbc0a90ba789401ed7a44356a44785644/websockets-16.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0704df094b2d5fa7f6f410925a594c2a5c9a09167731a76292e5410934208209", size = 188717, upload-time = "2026-07-10T06:32:04.156Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/aa/baedbbaa6bf9ed6029617ed5e8976535bd805f483ca9b3484e7ad9ee08bf/websockets-16.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b22b1f4950f6ab7126623329c3b47b3b90a14c05db517f2db2a026ad6c928352", size = 190090, upload-time = "2026-07-10T06:32:05.822Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/d813ec94e18002571ef4959d87a630eff6e01b72a51bcb0832b75ae8c51a/websockets-16.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1ae4a686a662964a6671069f84f7f908cc3475e782227726b0c622c715962105", size = 189320, upload-time = "2026-07-10T06:32:07.223Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3c/8ec52a6662f3df64090fba28cd521d405d54759268d8e820477037e8c80d/websockets-16.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:856bdd638f8277f86465057bfdd4da097c73058fb0f9d2bd5baea29e2bf2d367", size = 188068, upload-time = "2026-07-10T06:32:08.586Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7f/f0ae6042b14f86fa5f996c6563ea4cf107adc036ccbedc9d4f418d0095f9/websockets-16.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9003a1fde1c21a322a3ca3fa0c4bda8c639da81dbc925162766086643b05ba87", size = 185493, upload-time = "2026-07-10T06:32:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/89/ad/5ffc53af9939c49fd653d147fa5b8f78ced1f6bce6c49a7446860945b0ce/websockets-16.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e947b1f5fdab045174306e3916785bf3ed537648acc1549827c08c33b10953", size = 188141, upload-time = "2026-07-10T06:32:11.434Z" },
+    { url = "https://files.pythonhosted.org/packages/67/62/729206c0ee577a4db8eae6dd06e0eef725a1287c6df11b2ef831d003df31/websockets-16.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5dd0e666b5931c0509cf65714686a1c5126771e663a79ac5d40da4f58b1f9502", size = 186653, upload-time = "2026-07-10T06:32:12.845Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/86/e8806a99ec4589914f255e6b658853fe537bf359c05e6ba5762ad9c27917/websockets-16.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a0285df7925657ad65a65fb8dc330808bce082827538fd50ef45fa12d1fc5bca", size = 188614, upload-time = "2026-07-10T06:32:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/89/38/ac554e2fc6ff0b8deeff9798b92e7abd8f99e2bd9731532e7033de208220/websockets-16.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:82d1c2cab3c133e9d059b3a5420bed9376bd30e21c185c63dda4ddadf6ddda47", size = 186165, upload-time = "2026-07-10T06:32:15.626Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c5/4ef4d8e53342f94f3c49e1ae089b32c1e8b3878e15e0022c7708c647f351/websockets-16.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c39907f1eaf11f6277def65aa02d68f30576b693d0c1ca332aafa3caa723ac6d", size = 187119, upload-time = "2026-07-10T06:32:17.114Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/33/4788b1dd417bd97eeb2698af3b9df6775ac656f96e9987da0419a067602f/websockets-16.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45c5ea55446171949eb99fd34b771ceddd511ca21958d40d0197ced33159e5ee", size = 187411, upload-time = "2026-07-10T06:32:18.629Z" },
+    { url = "https://files.pythonhosted.org/packages/30/38/00d37aad6dc3244ce349e2864815362e50b3cfc00cac28d216db20efe40f/websockets-16.1-cp314-cp314-win32.whl", hash = "sha256:b8ef8b1c8d6bd029a475ac432e730fba2dfd456715d26c473e2a82291024b99c", size = 179822, upload-time = "2026-07-10T06:32:20.233Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/37/2a8cb0eaddee5eaebda47a90a3ba0898d1ce3d866b02a4857fea17d82e5b/websockets-16.1-cp314-cp314-win_amd64.whl", hash = "sha256:7358ff21632b5d062707f73e859c824f1c3807e73d8ca25e71caca7c4cdcf145", size = 180167, upload-time = "2026-07-10T06:32:21.749Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5a/262ad5fcaef4198997b165060f09a63f861e76939b1786ab546ccc3f8120/websockets-16.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d0f38f4c3e9b359e257c339c2cc1967ccaeedb102e57c1c986bdce4bf4f32268", size = 180166, upload-time = "2026-07-10T06:32:23.278Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/36377db690f4292826e4501a6dec2801dc55fd1cf0405923b04937e478df/websockets-16.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:3c3d2cbd1602593bad49bd86fa3fbb25407d87a3b4bf8857c0ac5ac4914e1901", size = 177697, upload-time = "2026-07-10T06:32:25.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c7/07171abce1e39799a76f473608580fe98bd43a1230f5146159622c02bccf/websockets-16.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:36069b74671e7e667f48a7484249f84c45a825a134c8b1bdc01875d0daa10d79", size = 177902, upload-time = "2026-07-10T06:32:26.564Z" },
+    { url = "https://files.pythonhosted.org/packages/14/17/c831f48e250bc4749f57c00dcce73337c41cd32f6d59a64567b84e782601/websockets-16.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:587f83c2ce8a5d628e166384d77fa7f0ac69b9007d515ab442123e6615aa8da3", size = 187766, upload-time = "2026-07-10T06:32:27.981Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/2e/4dfe63e245b0ecfaf470cf082d25c6ce35808159135fd88c82653a6b11ab/websockets-16.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6db7972d52bc1b66cefe2246902e256cbaebc9ba8a45eac09343d7eb6671b2", size = 188939, upload-time = "2026-07-10T06:32:29.365Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e5/5faf65aebd9562f6b4bc473d24ce38cc56f84eb5f5bee66ed9b86733f93c/websockets-16.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e7d6014888a0632e1ed7a4095248bb3095232999447f2d83bfb1900987dd9ed9", size = 191081, upload-time = "2026-07-10T06:32:30.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/cd/2634f2f2c0556c1aae6501ed6840019cc569dd6fdbcac6494378daea4dc0/websockets-16.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cb074d150e4ad2a77aa8a332c2be85f3f64f2681519d2570c1225c12c9821ff", size = 189513, upload-time = "2026-07-10T06:32:32.399Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/2c700b51196104f09715b326b1f092ed25326bdf79a03e00a4842e503743/websockets-16.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d19c9067e1fe9490f974bffbc0e443b80a7674c5efb4980c429cc00771f07c5a", size = 188240, upload-time = "2026-07-10T06:32:33.897Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/20/86283636e499a1a357fa9441f690ba34f255e731f2fea174132b3b762b57/websockets-16.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d440ff0c6c7469ad59c0a412c383c235935b43635e89425e3f6a0c36de90c31b", size = 185955, upload-time = "2026-07-10T06:32:35.279Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/d7fb734b0095d43bc7f1c9f68afd50adb4176e7e513403e8c70ad7daa4fa/websockets-16.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8613129a2533f08de24505e69a3e403cedaadae49abdb043c4d170ca71b7e4bd", size = 188491, upload-time = "2026-07-10T06:32:36.673Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/168a192689db468405ecf3b8e4a2c18811936b0724d017ad7e6d252734f0/websockets-16.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a5bf9c23f197b4ec88290fd5463f33db67362a1bb10f85fc2e8e7627f0ddab97", size = 186983, upload-time = "2026-07-10T06:32:38.207Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9b/66795fa91ebe49019ebe4fa910282172252e37046b80e08fc52e0c365150/websockets-16.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:520b0fd0395f075febb283c76755af724ab9fd19dffa4f3bfd18cb4e622790a3", size = 188890, upload-time = "2026-07-10T06:32:39.545Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/32/126bbc844be5afb3613fd43211dac10a9645f4cf39741d04acaa2ec7030c/websockets-16.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:7143aa09a67e1c013be44e81a88dfe90fc6244198ab86c7edd064152cf619805", size = 186583, upload-time = "2026-07-10T06:32:41.038Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b9/0b5db9cbcf6e4970db4496893244a8d92e07f71a8ef27cf34b08aa02fef1/websockets-16.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:7acb811fad08e611755800d1560e395c67e11a6bd563598ea6abb319afb86938", size = 187353, upload-time = "2026-07-10T06:32:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/99/2e/254b2131a10d831b76e2c18dfe7add9729c6292c674a8085bf8de01ad151/websockets-16.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c5cf88e3faa2f7931bc6baeee7599c97656a3f6ac7f831f4fccba233e141783a", size = 187784, upload-time = "2026-07-10T06:32:43.929Z" },
+    { url = "https://files.pythonhosted.org/packages/21/dc/e7288aa8e3ac5a88a0924619984d663c1abf2a87d0ea98290c66fdaee0ec/websockets-16.1-cp314-cp314t-win32.whl", hash = "sha256:589f8842521c8307684ce0b40ce4ad70c5e0aa46484c6f1225a94ef4b8970341", size = 179947, upload-time = "2026-07-10T06:32:45.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/de/37edf1260ff0fbbd2f82433489c4cfbe799ac2ff21355331609879329fe6/websockets-16.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c0e0857c30bbbc2bb5c30687508f0b7ec19aa026cd9f2ff8424d0fee42dcc07", size = 180291, upload-time = "2026-07-10T06:32:47.119Z" },
+    { url = "https://files.pythonhosted.org/packages/66/58/bd83247f39ddc26ffc2c24eb05087a3b749e00cb4509fc6d19daa23c8495/websockets-16.1-py3-none-any.whl", hash = "sha256:c5149dfe490ec7e5ee5dbf624c642fb725f93a5575c7f00ab594ca9eddb8dd81", size = 174031, upload-time = "2026-07-10T06:32:56.079Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
*Issue #, if available:* Closes #294

> **[Major Update 2/17]** This pull request is part of the RAPID major update series — one issue and one pull request per part, merged in numeric order. You can list every part of the series by searching issues and pull requests for "[Major Update". *(A Japanese version follows the English text. / 日本語版は英語の後にあります。)*

## What

- The CDK model parameters collapse into one. `documentProcessingModelId` / `imageReviewModelId` become a single `defaultModelId`: per-item model selection from `availableModels` overrides the two old parameters, so they had effectively lost their meaning. The old names and the CloudShell `--document-model` / `--image-model` flags stay accepted as deprecated aliases. Amazon Bedrock now runs in the region where the stack is deployed (one legacy exception is listed under "Breaking changes"). **This is a breaking change to the CDK parameters** — what an existing deployment should do is under "Breaking changes" below.
- The review agent runtime is upgraded (bedrock-agentcore SDK from v0.1.0 to 1.18, refreshed Strands Agents and tooling) and the AgentCore idle session timeout is pinned to 900 seconds. Reviews previously shared a single AgentCore runtime session across checklist items; each review item now runs in its own session (session IDs share the review job's prefix, so a job's sessions can still be listed together), which reduces errors and lets review items run in parallel. Long-running review items no longer get terminated mid-invocation with a persistent `RuntimeClientError`.
- The prompt caching that #309 introduced is completed for cross-item reuse: the document-block path now places an explicit cache point between the document blocks and the per-item prompt, so review items that share the same documents, model, and tool configuration read the document prefix from cache from the second item onward (the automatic placement put the boundary after the per-item prompt, which made the cached prefix differ per item). The image/file-read path is structurally limited to within-item multi-turn reuse, because file contents enter the conversation as tool results after the per-item prompt. The `strands-agents` floor rises to 1.52.0, the first release that honors a manually placed cache point (older 1.30-1.51 silently move it to the end of the message).
- The agent no longer injects historical human feedback into its prompt: the `<HISTORICAL_FEEDBACK>` section built from past reviewer corrections is removed from prompt assembly. The old mechanism applied that feedback to later reviews implicitly, without showing users what was being applied — that poor visibility is why it goes away. Review results now depend only on the checklist item, the documents, and information obtained through the configured tools (deterministic prompts, no cross-review leakage of reviewer comments). Stored `feedback_summary` data is left untouched, and part 15 introduces override aggregation as the successor signal for reviewer corrections. See "Breaking changes".
- A refreshed model lineup: Claude Sonnet 5 (Global) and Claude Opus 4.8 / 4.7 (Global and JP inference profiles) join `availableModels`, Claude Sonnet 4.6 and Claude Haiku 4.5 gain JP profiles, Claude Sonnet 4 (Global) leaves the bundled list, and the app-wide default model becomes Claude Sonnet 5 (Global).
- The agent's file-access tool now reads only inside the review's own workspace. MCP tools gain an environment-variable blocklist and stricter configuration validation.
- The refreshed agent carries forward part 1's runtime MCP dependency constraint: stdio MCP child processes keep receiving the SDK's default environment plus `UV_CONSTRAINT` pointing at the shipped `mcp-uv-constraints.txt` (`mcp<2`), so review-time `uvx` resolutions stay clear of the breaking mcp 2.0.0 release. The builder falls back to the previous behavior when the constraint file is absent and adds nothing else to the child environment (host credentials stay out); this part adds dedicated tests for it.
- Backend workflow and agent logging drops to metadata on the normal path (item counts, response lengths, log level pinned to INFO), so successful runs no longer write document contents to CloudWatch Logs in plain text. One verbatim log remains by design: the AgentCore response body is still logged when a call returns non-200, for failure diagnosis.
- Model names in the checklist UI come from one shared formatter: an item without an explicit model shows the resolved default model instead of a bare marker, and unknown model IDs are shown as-is rather than dropped.
- The frontend gains its test infrastructure here: vitest, jsdom, and fast-check are wired up as `npm test`, and the local development guide documents the command. The first suite lands together with it — property-based tests for the model label helper this part introduces. Later frontend parts ship their tests on top of this.
- The model documentation is updated in English and Japanese (the README's Bedrock parameter rows, model step, and pricing section, plus the AI Model Customization guide).

## Why

This part establishes the model and agent foundation for the series. Later per-item model work assumes one default plus a per-item selection list; settling that shape first keeps new code paths from threading two parameter names. The idle-session fix and the file-access / MCP hardening ship here because they live in the same agent runtime this part upgrades — splitting them off would mean touching the same files twice. Nothing changes in the database, so this can be reviewed as a configuration and runtime change.

## Review guide

- The entry point is `cdk/lib/parameter-schema.ts`: the new `defaultModelId`, the two deprecated aliases, and the normalization that fills `defaultModelId` when only an old name is set. Whether an existing deployment keeps working unchanged is decided here, and **this is the part we would most like reviewed**.
- The constructs that consume it (agent, review processor, checklist processor, ambiguity detection processor) go from two model properties to one, and the Bedrock region environment variable disappears.
- The `invoke-agent` Lambda handler (`cdk/lib/constructs/lambda/invoke-agent/index.ts`) switches to per-item runtime sessions and, on the normal path, logs only non-sensitive metadata (the response body is still logged verbatim on non-200 calls).
- In the agent package, `tools/file_access.py` (workspace confinement) and `tools/mcp_validation.py` (environment blocklist, configuration validation) each come with a new test file.
- On the frontend side: the model label helper and the `ModelSelector` change — plus the new test infrastructure (the vitest config, the `npm test` script and devDependencies, and the first suite).
- The CloudShell entry points (`bin.sh`, `deploy.yml`) just map the old flags onto the single parameter.
- `review-item-processor/uv.lock` is a mechanical dependency update that GitHub collapses by default; the dependency change worth reviewing is in `pyproject.toml`. The three READMEs under `review-item-processor/evals/` get formatting, Japanese wording, and small usage-instruction fixes (fixture-directory setup, corrected relative paths, a corrected directory-structure diagram) with no changes to the evals code — they ride along with this part's agent-package refresh. Documentation reads best last, English then Japanese.

## How verified

Measured on a clean checkout of exactly this tree:

- `backend`: `npm run format:check`, `npx prisma validate`, `npm run prisma:generate`, and `npm run build` (tsc) are clean; `npx vitest run` passes (5 files / 32 tests).
- `frontend`: `npm run format:check`, `npm run build`, and `VITE_APP_BASE_PATH=/app/ npm run build` are clean, and the `npm test` (vitest) entry point introduced in this part passes (1 file / 2 tests). Every translation key referenced by the frontend exists in both `en.json` and `ja.json` (455 references).
- `cdk`: `npm run build` and `npx jest` pass (3 suites / 36 tests), and `npx cdk synth` succeeds with no AWS credentials available.
- `review-item-processor`: `uv sync --extra dev` resolves with the upgraded SDK (strands-agents 1.52.0, bedrock-agentcore 1.18.0), and `uv run pytest` reports 144 passed / 2 skipped. The two skips are intentional: `test_mcp.py::test_mcp_with_uvx` skips when no real S3 bucket is configured (the guard #309 added), and the Bedrock integration test in `tests/test_citation.py` is opt-in via `RUN_BEDROCK_INTEGRATION=1`.
- Model resolution over HTTP: starting the backend with `AVAILABLE_MODELS` (two models) and `DEFAULT_MODEL_ID` set, `GET /models` returns those two models and the configured default (HTTP 200).
- Local smoke run: the seven endpoints exercised by the local development guide all return 200, with no server errors logged.
- Database: this part adds no migrations. Running `prisma migrate deploy` against a database that already had the existing 12 migrations reports nothing to apply and leaves its rows untouched.
- Docs: links, anchors, and image references were checked across the EN/JA pairs (136 references, all resolved), and `README.md` and `docs/ja/README_ja.md` stay line-in-sync (278 lines each).

## Documentation

English and Japanese documents are updated together:

- `README.md` / `docs/ja/README_ja.md`: the Bedrock parameter rows are replaced with `defaultModelId` and `availableModels`. The CloudShell model step now notes that Bedrock uses the deployment region, the AI Model Customization summary points at the single default model, and the pricing section is rewritten around model classes.
- `docs/en/deployment-options.md` / `docs/ja/deployment-options.md`: AI Model Customization is rewritten — the bundled model list, notes on regions and inference profiles, configuration examples, how to register token prices when you add a model, and the `--default-model` flag.

## Migrations

None.

## Security fixes

- The review agent's file-access tool is confined to the review's own workspace, preventing path traversal / local file inclusion through a crafted path.
- MCP tool configuration is validated more strictly, and an environment-variable blocklist keeps a tool configuration from injecting sensitive variables into the runtime.
- The agent's S3 temporary-storage helper no longer trusts the bucket named inside an S3 reference: resolving and cleaning up temporary data are pinned to the configured bucket, and a reference pointing at any other bucket is rejected (fail-closed), so a forged reference cannot make the agent read from or delete in another bucket.
- Related (listed under "What" rather than as a security fix): workflow and agent logs now carry metadata only on the normal path, so successful runs no longer send document contents to CloudWatch Logs in plain text (the AgentCore response body is still logged verbatim on non-200 calls, for failure diagnosis).

## Breaking changes

Yes — the CDK parameters for model selection change. Old names keep working as deprecated aliases, but whether an existing configuration synthesizes unchanged now depends on one new consistency check (the "New consistency check" bullet below), so you should migrate:

- Rename `documentProcessingModelId` / `imageReviewModelId` in `cdk/lib/parameter.ts` to `defaultModelId`, or pass `--default-model` in CloudShell. The old names and the `--document-model` / `--image-model` flags are still accepted and normalized to `defaultModelId`, and will be removed in a future release.
- The CloudShell CloudFormation template (`deploy.yml`) replaces its `DocumentProcessingModelId` / `ImageReviewModelId` parameters with a single `DefaultModelId`, and the stack stops exporting the `BedrockRegion` output. A `DefaultModelId` output is added; the `DocumentProcessingModelId` and `ImageReviewModelId` outputs remain for now as deprecated echoes of the consolidated value. Update any tooling that reads these parameters or outputs.
- New consistency check: when `availableModels` is non-empty, the resolved `defaultModelId` — including a value normalized from the old parameter names — must be one of its entries, or `cdk synth` fails fast with a message naming the valid choices. If you point the old names at a custom model while keeping the bundled `availableModels`, add that model to `availableModels` (or pick a bundled one as the default). A configuration with an empty `availableModels` (which hides the per-item selection UI) is exempt.
- If you currently set the two old names to different models, only one value survives the normalization (`documentProcessingModelId` takes precedence). Choose the model you want as the app-wide default, and select any exceptions per checklist item from `availableModels`.
- Amazon Bedrock now runs in the region where the stack is deployed (one residual: the legacy `bedrockRegion` value still reaches the experimental Feedback Aggregator — and only it — until part 15 removes that construct). Before deploying, confirm that `defaultModelId` and every entry in `availableModels` are enabled in that region; cross-region inference profiles (`global.` / `us.` / `eu.` / `apac.` / `jp.`) are covered in the AI Model Customization guide.
- If you do not set `defaultModelId` at all, the default becomes Claude Sonnet 5 (Global).
- The review agent stops feeding past human feedback (`<HISTORICAL_FEEDBACK>`) into subsequent reviews. If your workflow relied on manual corrections influencing later runs, be aware this loop is intentionally removed in this part. Stored `feedback_summary` data remains in the database, and part 15 (override aggregation) becomes the way reviewer corrections are surfaced.

---

# 日本語（Japanese）

> **[Major Update 2/17]** 本 PR は RAPID メジャーアップデートシリーズの一部です。各回は Issue 1 件と Pull Request 1 件で構成され、番号順にマージされます。シリーズ全体は Issue / Pull Request を「[Major Update」で検索すると一覧できます。

**タイトル（参考訳）**: feat(agent): AgentCore ランタイムの更新とモデルラインアップの刷新

## 変更内容（What）

- CDK のモデルパラメータを 1 つに集約しました。`documentProcessingModelId` / `imageReviewModelId` は単一の `defaultModelId` になります。旧 2 パラメータは `availableModels` からの項目単位のモデル選択で上書きされるため、実質的に意味を持たなくなっていました。旧パラメータ名と CloudShell の `--document-model` / `--image-model` フラグは非推奨エイリアスとして引き続き利用できます。Amazon Bedrock はスタックのデプロイ先リージョンで実行されます（旧来の例外が 1 点あり、「破壊的変更」に記載）。**CDK パラメータの破壊的変更**を含むため、既存デプロイでの対応は後述の「破壊的変更」にまとめています。
- 審査エージェントのランタイムを更新しました（bedrock-agentcore SDK を v0.1.0 から 1.18 へ、Strands Agents とツール群も更新）。AgentCore のアイドルセッションタイムアウトは 900 秒に固定します。従来は単一の AgentCore ランタイムセッションで複数のチェック項目を審査していましたが、セッションは審査項目ごとに分離しました（セッション ID は審査ジョブの接頭辞を共有するため、ジョブのセッションはまとめて一覧できます）。これによりエラーが減り、審査の並列化も可能になります。長時間かかる審査項目が処理の途中で打ち切られて `RuntimeClientError` を繰り返す問題は起きなくなります。
- #309 で導入されたプロンプトキャッシュを、項目間の再利用が効く形に仕上げます。document-block 経路では文書ブロックと項目別プロンプトの間に明示的なキャッシュポイントを置くため、同じ文書・モデル・ツール構成を共有する審査項目は 2 項目目以降、文書プレフィックスをキャッシュから読めます（自動配置ではキャッシュ境界が項目別プロンプトの後になり、キャッシュキーが項目ごとに変わっていました）。画像 / file-read 経路は、ファイル内容が項目別プロンプトより後のツール結果として会話に入る構造のため、同一項目内のマルチターン再利用に留まります。`strands-agents` の下限は、手動配置のキャッシュポイントを尊重する最初のリリースである 1.52.0 へ引き上げます（1.30〜1.51 は手動配置を黙ってメッセージ末尾へ移動します）。
- エージェントはプロンプトへ過去の人手フィードバックを注入しなくなります: 過去のレビュアー修正から組み立てていた `<HISTORICAL_FEEDBACK>` セクションをプロンプト構築から削除します。従来の仕組みは、フィードバックの内容をユーザーへ明示的に表示しないまま、以後の審査で AI が暗黙的に利用するもので、この可視性の悪さが廃止の理由です。審査結果はチェック項目・書類・設定済みツールで得た情報のみに基づくようになります（プロンプトの決定性を保ち、レビュアーコメントの審査間リークを防ぎます）。保存済みの `feedback_summary` データはそのまま残り、レビュアー修正を反映する後継の仕組みは第 15 回のオーバーライド集計が担います。「破壊的変更」もご覧ください。
- モデルラインアップの刷新。`availableModels` に Claude Sonnet 5（Global）と Claude Opus 4.8 / 4.7（Global・JP の推論プロファイル）が加わり、Claude Sonnet 4.6 と Claude Haiku 4.5 に JP プロファイルが追加され、Claude Sonnet 4（Global）は同梱リストから外れます。アプリ全体の既定モデルは Claude Sonnet 5 (Global) になります。
- エージェントのファイルアクセスツールは、その審査自身のワークスペース内だけを読めるように制限。MCP ツールには環境変数のブロックリストと、より厳格な設定検証が入ります。
- 刷新後のエージェントは、第 1 回（1/17）で導入した実行時の MCP 依存制約を引き継ぎます: stdio MCP 子プロセスには引き続き SDK 既定の環境変数に加えて、同梱の `mcp-uv-constraints.txt`（`mcp<2`）を指す `UV_CONSTRAINT` を渡すため、審査実行時の `uvx` 解決は破壊的な mcp 2.0.0 を取得しない状態を維持します。制約ファイルが無い環境では従来挙動へフォールバックし、子プロセス環境にはそれ以外を一切追加しません（ホストの資格情報は渡りません）。本回でこの挙動の専用テストを追加しています。
- バックエンドのワークフローとエージェントのログは、正常経路ではメタデータのみ（項目数・応答長、ログレベルは INFO 固定）になり、成功した実行が書類の内容を CloudWatch Logs へ平文で書き出すことはなくなります。設計上の例外が 1 つあり、呼び出しが非 200 を返した場合の AgentCore 応答本文は、障害診断のため引き続きそのまま記録されます。
- チェックリスト UI のモデル名表示は共通の整形器 1 本に統一しました。モデル未指定の項目に出るのは単なるマーカーではなく解決後の既定モデルになり、未知のモデル ID も欠落させずそのまま表示します。
- フロントエンドのテスト基盤は本回で入ります: vitest・jsdom・fast-check を `npm test` として配線し、ローカル開発ガイドにコマンドを記載します。最初のスイートも同時に入ります — 本回で導入するモデルラベルのヘルパーのプロパティベーステストです。以降のフロントエンド回は、この上にテストを載せていきます。
- モデル関連のドキュメント（README の Bedrock パラメータ行・モデル手順・料金セクション、AI Model Customization ガイド）を英語・日本語で更新しています。

## 背景（Why）

この回で、以降のシリーズが使うモデル・エージェント基盤を確立します。後続の項目単位モデル対応は「既定モデル 1 つ + 項目ごとの選択リスト」を前提とするため、先に確定すれば新しいコードパスへ 2 つのパラメータ名を通す必要がなくなります。アイドルセッションの修正とファイルアクセス / MCP の強化を同じ回に入れたのは、どれも今回更新するエージェントランタイムと同じ場所にあるからです。分けると同じファイルを 2 度触ることになります。データベースには触れないため、設定とランタイムの変更としてレビューできます。

## レビューガイド（Review guide）

- 入口は `cdk/lib/parameter-schema.ts` です。新しい `defaultModelId`、2 つの非推奨エイリアス、旧名だけが設定されている場合に `defaultModelId` を補完する正規化処理が並びます。既存デプロイがそのまま動き続けるかはここで決まるので、**いちばん見ていただきたい箇所**です。
- それを消費する側のコンストラクト（agent、review processor、checklist processor、ambiguity detection processor）は、モデル用プロパティが 2 つから 1 つになり、Bedrock リージョンの環境変数が消えます。
- `invoke-agent` Lambda ハンドラ（`cdk/lib/constructs/lambda/invoke-agent/index.ts`）は項目単位のランタイムセッションへ切り替わり、正常経路のログは非機微なメタデータのみになります（非 200 の呼び出しでは応答本文が引き続きそのまま記録されます）。
- エージェントパッケージでは `tools/file_access.py`（ワークスペース制限）と `tools/mcp_validation.py`（環境変数ブロックリスト・設定検証）。それぞれ新設のテストファイルが付きます。
- フロントエンド側はモデルラベルのヘルパーと `ModelSelector` の変更 — 加えて新設のテスト基盤（vitest 設定、`npm test` スクリプトと devDependencies、最初のスイート）。
- CloudShell の入口（`bin.sh`・`deploy.yml`）は、旧フラグを単一パラメータへ写しているだけです。
- `review-item-processor/uv.lock` は機械的な依存更新で、GitHub では既定で折りたたまれます。レビューすべき依存変更は `pyproject.toml` 側にあります。`review-item-processor/evals/` 配下の README 3 本は、整形・日本語の文体調整と利用手順の小修正（fixtures ディレクトリの作成手順、相対パスの修正、ディレクトリ構造図の修正）のみで、evals のコードには変更がありません — 本回のエージェントパッケージ刷新に同乗しています。ドキュメントは最後に、英語 → 日本語の順で読むのが早いはずです。

## 検証方法（How verified）

本 PR のツリーそのものをクリーンにチェックアウトした状態で実測しました:

- `backend`: `npm run format:check`・`npx prisma validate`・`npm run prisma:generate`・`npm run build`（tsc）がいずれもクリーン。`npx vitest run` は 5 ファイル / 32 テストが通過。
- `frontend`: `npm run format:check`・`npm run build`・`VITE_APP_BASE_PATH=/app/ npm run build` がクリーン。本回で新設した `npm test`（vitest）は 1 ファイル / 2 テスト通過。フロントエンドが参照する翻訳キーは `en.json`・`ja.json` の両方に存在します（455 件）。
- `cdk`: `npm run build`・`npx jest` が通過（3 スイート / 36 テスト）。`npx cdk synth` は AWS 資格情報が無い状態でも成功。
- `review-item-processor`: `uv sync --extra dev` が更新後の SDK（strands-agents 1.52.0・bedrock-agentcore 1.18.0）で解決し、`uv run pytest` は 144 passed / 2 skipped。2 件の skip は意図どおりです — `test_mcp.py::test_mcp_with_uvx` は実 S3 バケット未設定時に skip（#309 で追加されたガード）、`tests/test_citation.py` の Bedrock 統合テストは `RUN_BEDROCK_INTEGRATION=1` のオプトインです。
- モデル解決の HTTP 確認: `AVAILABLE_MODELS`（2 モデル）と `DEFAULT_MODEL_ID` を与えてバックエンドを起動すると、`GET /models` がその 2 モデルと設定した既定モデルを返します（HTTP 200）。
- ローカル起動スモーク: ローカル開発ガイドで使う 7 つのエンドポイントがすべて 200 を返し、サーバエラーのログはありません。
- データベース: 本回のマイグレーション追加はゼロ。既存の 12 本が適用済みのデータベースに `prisma migrate deploy` を実行しても適用対象は無く、既存行も変わりません。
- ドキュメント: EN/JA ペア全体でリンク・アンカー・画像参照を検査して 136 件すべて解決。`README.md` と `docs/ja/README_ja.md` は行単位で同期しています（各 278 行）。

## ドキュメント（Documentation）

英語・日本語のドキュメントは同時に更新しています:

- `README.md` / `docs/ja/README_ja.md`: Bedrock のパラメータ行は `defaultModelId`・`availableModels` に置き換わります。CloudShell のモデル手順には Bedrock がデプロイ先リージョンで動く旨が入り、AI Model Customization の要約は単一の既定モデルを指すようになります。料金セクションはモデルクラス基準で書き直しました。
- `docs/en/deployment-options.md` / `docs/ja/deployment-options.md`: AI Model Customization を全面的に書き直しました。同梱モデルの一覧、リージョンと推論プロファイルの注意点、設定例、モデルを追加する際のトークン価格の登録方法、`--default-model` フラグを扱います。

## マイグレーション（Migrations）

なし。

## セキュリティ修正（Security fixes）

- 審査エージェントのファイルアクセスツールをその審査自身のワークスペース内に限定し、細工されたパスによるパストラバーサル / ローカルファイルインクルージョンを防ぎます。
- MCP ツールの設定検証を厳格化しました。環境変数のブロックリストにより、ツール設定から機微な環境変数をランタイムへ注入することはできません。
- エージェントの S3 一時ストレージ処理は、S3 参照の中に書かれたバケット名を信頼しなくなります。一時データの取得と削除は構成で定めたバケットに固定され、他のバケットを指す参照は拒否します（フェイルクローズ）。細工された参照でエージェントに別バケットの読み取りや削除をさせることはできません。
- 関連事項（セキュリティ修正ではなく「変更内容」側に記載）: ワークフローとエージェントのログは正常経路でメタデータのみになったため、成功した実行が書類の内容を平文で CloudWatch Logs へ送ることはなくなります（非 200 の呼び出しでは、障害診断のため AgentCore 応答本文が引き続きそのまま記録されます）。

## 破壊的変更（Breaking changes）

あります。モデル選択に関する CDK パラメータが変わります。旧名は非推奨エイリアスとして動き続けますが、既存構成がそのまま synth を通るかどうかは新設の整合性検査 1 点（下記「新設の整合性検査」の項目）に依存するため、次の移行をおすすめします:

- `cdk/lib/parameter.ts` の `documentProcessingModelId` / `imageReviewModelId` を `defaultModelId` にリネームするか、CloudShell では `--default-model` を渡してください。旧名と `--document-model` / `--image-model` フラグは引き続き受け付けられ `defaultModelId` へ正規化されますが、将来のリリースで削除されます。
- CloudShell の CloudFormation テンプレート（`deploy.yml`）のパラメータは、`DocumentProcessingModelId` / `ImageReviewModelId` に代わって単一の `DefaultModelId` になります。スタック出力からは `BedrockRegion` が削除され、`DefaultModelId` 出力が加わります。`DocumentProcessingModelId` と `ImageReviewModelId` の両出力は当面残りますが、統合後の値をそのまま返す非推奨のエコーです。これらのパラメータや出力を読み取る仕組みがあれば更新してください。
- 新設の整合性検査: `availableModels` が空でない場合、解決後の `defaultModelId`（旧パラメータ名から正規化された値を含む）がその一覧に含まれていないと、`cdk synth` が有効な選択肢を示すメッセージとともに fail-fast します。旧名で独自モデルを指定しつつ同梱の `availableModels` を使い続ける構成では、そのモデルを `availableModels` へ追加する（または既定を一覧内のモデルにする）必要があります。`availableModels` を空にする構成（項目単位のモデル選択 UI を隠す）は検査対象外です。
- 2 つの旧名に異なるモデルを設定している場合、正規化後に残るのは一方の値だけです（`documentProcessingModelId` が優先）。アプリ全体の既定にしたいモデルを選び、例外はチェックリスト項目ごとに `availableModels` から選択してください。
- Amazon Bedrock はスタックをデプロイしたリージョンで実行されます（残存が 1 点: 旧 `bedrockRegion` の値は本回時点では実験的な Feedback Aggregator にのみ届き続けます。第 15 回で当該コンストラクトごと削除されます）。デプロイ前に、`defaultModelId` と `availableModels` の各エントリがそのリージョンで有効になっていることをご確認ください。クロスリージョン推論プロファイル（`global.` / `us.` / `eu.` / `apac.` / `jp.`）は AI Model Customization ガイドで説明しています。
- `defaultModelId` を設定しない場合の既定モデルは Claude Sonnet 5 (Global) です。
- 審査エージェントは過去の人手フィードバック（`<HISTORICAL_FEEDBACK>`）を以後の審査へ反映しなくなります。人手修正が後続の実行へ影響することに依存した運用をしている場合は、本回でこのループが意図的に廃止される点にご注意ください。保存済みの `feedback_summary` データはデータベースに残り、レビュアー修正の反映は第 15 回のオーバーライド集計が後継になります。

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
