### PR TITLE
feat(agent): cache document/image prompt prefix across review items

### DIFF
--- a/review-item-processor/agent.py
+++ b/review-item-processor/agent.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import boto3
 from strands import Agent
 from strands.models import BedrockModel
+from strands.models.model import CacheConfig
 from strands.tools.mcp import MCPClient
 from strands_tools import file_read, image_reader
 
@@ -105,6 +106,12 @@ BEDROCK_REGION = os.environ.get("BEDROCK_REGION", "us-west-2")
 ENABLE_CITATIONS = os.environ.get("ENABLE_CITATIONS", "true").lower() == "true"
 # Tool text truncate length
 TOOL_TEXT_TRUNCATE_LENGTH = 500
+
+
+def _apply_cache_config(bedrock_config: Dict[str, Any]) -> None:
+    """Enable auto prompt caching so the document/image prefix is cached too."""
+    bedrock_config["cache_config"] = CacheConfig(strategy="auto")
+    bedrock_config["cache_tools"] = "default"
 
 
 def supports_caching(model_id: str) -> bool:
@@ -432,9 +439,10 @@ def _run_agent_with_file_read_tool(
     }
 
     if model_supports_cache:
-        bedrock_config["cache_prompt"] = "default"  # Enable system prompt caching
-        bedrock_config["cache_tools"] = "default"  # Enable tool definitions caching
-        logger.debug("Caching enabled for system prompt and tools")
+        # Auto strategy caches the document/image content too, not just
+        # system prompt + tools.
+        _apply_cache_config(bedrock_config)
+        logger.debug("Caching enabled (auto strategy)")
     else:
         logger.debug("Caching disabled - model does not support prompt caching")
 
@@ -546,8 +554,8 @@ def _run_agent_with_document_block(
     }
 
     if model.supports_caching:
-        bedrock_config["cache_prompt"] = "default"
-        bedrock_config["cache_tools"] = "default"
+        # Auto strategy caches the PDF/document prefix for items 2..N of a job.
+        _apply_cache_config(bedrock_config)
 
     agent = Agent(
         model=BedrockModel(**bedrock_config),

--- a/review-item-processor/agent.py
+++ b/review-item-processor/agent.py
@@ -439,8 +439,6 @@ def _run_agent_with_file_read_tool(
     }
 
     if model_supports_cache:
-        # Auto strategy caches the document/image content too, not just
-        # system prompt + tools.
         _apply_cache_config(bedrock_config)
         logger.debug("Caching enabled (auto strategy)")
     else:
@@ -554,7 +552,6 @@ def _run_agent_with_document_block(
     }
 
     if model.supports_caching:
-        # Auto strategy caches the PDF/document prefix for items 2..N of a job.
         _apply_cache_config(bedrock_config)
 
     agent = Agent(

--- a/review-item-processor/pyproject.toml
+++ b/review-item-processor/pyproject.toml
@@ -3,7 +3,7 @@ name = "review-item-processor"
 version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
-    "strands-agents>=1.15.0",
+    "strands-agents>=1.30.0",
     "strands-agents-tools[agent_core_code_interpreter]>=0.2.14",
     "bedrock-agentcore==0.1.0",
     "pillow>=11.2.1",

--- a/review-item-processor/test_mcp.py
+++ b/review-item-processor/test_mcp.py
@@ -4,12 +4,13 @@
 import os
 
 import boto3
+import pytest
 
 from agent import process_review
 
 
 def get_config():
-    """Get AWS configuration"""
+    """Get AWS configuration; 'is_real' is False when falling back to a placeholder bucket."""
     try:
         cfn = boto3.client("cloudformation")
         response = cfn.describe_stacks(StackName="RapidStack")
@@ -19,35 +20,45 @@ def get_config():
         return {
             "document_bucket": outputs["DocumentBucketName"],
             "document_model_id": outputs["DocumentProcessingModelId"],
+            "is_real": True,
         }
     except:
+        env_bucket = os.environ.get("DOCUMENT_BUCKET")
         return {
-            "document_bucket": os.environ.get("DOCUMENT_BUCKET", "test-bucket"),
+            "document_bucket": env_bucket or "test-bucket",
             "document_model_id": os.environ.get(
                 "DOCUMENT_PROCESSING_MODEL_ID",
                 "global.anthropic.claude-sonnet-4-6",
             ),
+            "is_real": env_bucket is not None,
         }
 
 
 def test_mcp_with_uvx():
     """Test MCP integration using uvx and AWS docs MCP server"""
-    print("🧪 Testing MCP integration with AWS documentation server...")
+    print("Testing MCP integration with AWS documentation server...")
 
     config = get_config()
+
+    # Requires a real S3 bucket to upload the fixture PDF to.
+    if not config["is_real"]:
+        pytest.skip(
+            "No S3 bucket configured (set DOCUMENT_BUCKET or deploy RapidStack); "
+            "skipping MCP integration test that uploads to S3"
+        )
 
     # Use real PDF from examples
     test_pdf = "../examples/ja/ユースケース003_車庫申請/申請書例.pdf"
 
     if not os.path.exists(test_pdf):
-        print(f"❌ Test PDF not found: {test_pdf}")
+        print(f"Test PDF not found: {test_pdf}")
         return
 
     # Upload to S3
     s3 = boto3.client("s3")
     test_key = "test/test_mcp_doc.pdf"
     s3.upload_file(test_pdf, config["document_bucket"], test_key)
-    print(f"✅ Uploaded to S3: {test_key}")
+    print(f"Uploaded to S3: {test_key}")
 
     try:
         # MCP configuration - AWS documentation server via uvx
@@ -66,7 +77,7 @@ def test_mcp_with_uvx():
             toolConfiguration=tool_config,
         )
 
-        print("\n✅ Test completed successfully")
+        print("\nTest completed successfully")
         print(f"   Result: {result.get('result')}")
         print(f"   Confidence: {result.get('confidence')}")
 
@@ -78,7 +89,7 @@ def test_mcp_with_uvx():
         # Check if MCP tools were used
         if "verificationDetails" in result:
             sources = result["verificationDetails"].get("sourcesDetails", [])
-            print("\n   📋 Tool usage:")
+            print("\n   Tool usage:")
             print(f"      Total tool calls: {len(sources)}")
 
             mcp_tools_used = [
@@ -95,24 +106,24 @@ def test_mcp_with_uvx():
             ]
 
             if mcp_tools_used:
-                print(f"      ✅ MCP tools used: {len(mcp_tools_used)}")
+                print(f"      MCP tools used: {len(mcp_tools_used)}")
                 for tool in mcp_tools_used[:3]:  # Show first 3
                     print(f"         - {tool.get('toolName')}")
             else:
-                print("      ⚠️  No MCP tools detected in tool history")
+                print("      No MCP tools detected in tool history")
         else:
-            print("\n   ❌ verificationDetails field missing!")
+            print("\n   verificationDetails field missing!")
 
         if "reviewMeta" in result:
             meta = result["reviewMeta"]
-            print("\n   💰 Cost:")
+            print("\n   Cost:")
             print(
                 f"      Tokens: {meta.get('input_tokens', 0)} input, {meta.get('output_tokens', 0)} output"
             )
             print(f"      Cost: ${meta.get('total_cost', 0):.6f}")
 
     except Exception as e:
-        print(f"❌ Test failed: {e}")
+        print(f"Test failed: {e}")
         import traceback
 
         traceback.print_exc()

--- a/review-item-processor/tests/test_citation.py
+++ b/review-item-processor/tests/test_citation.py
@@ -1,204 +1,137 @@
 #!/usr/bin/env python3
-"""
-Local test for process_review function with citation functionality
+"""Citation tests for agent.py.
 
-Run with: poetry run pytest tests/test_citation.py -v
+Offline tests cover _should_use_document_block (routing) and
+_extract_citations_text (parsing). An opt-in Bedrock integration test runs only
+with RUN_BEDROCK_INTEGRATION=1 (needs AWS credentials).
 """
 import os
 import sys
-import tempfile
-import shutil
 from pathlib import Path
 
-# Add parent directory to path
+import pytest
+
+# Add parent directory to path so `import agent` works when run from any cwd.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-def setup_test_environment():
-    """Setup test environment variables"""
-    os.environ["ENABLE_CITATIONS"] = "true"
-    os.environ["BEDROCK_REGION"] = "us-west-2"
-    os.environ["DOCUMENT_PROCESSING_MODEL_ID"] = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-    os.environ["IMAGE_REVIEW_MODEL_ID"] = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-    
-    print("Environment variables set:")
-    print(f"  ENABLE_CITATIONS: {os.environ.get('ENABLE_CITATIONS')}")
-    print(f"  BEDROCK_REGION: {os.environ.get('BEDROCK_REGION')}")
-    print(f"  DOCUMENT_MODEL: {os.environ.get('DOCUMENT_PROCESSING_MODEL_ID')}")
+import agent
+from agent import _extract_citations_text, _should_use_document_block
+from model_config import ModelConfig
 
-def test_citation_functionality():
-    """Test citation functionality with local PDF file"""
-    
-    # Setup environment
-    setup_test_environment()
-    
-    # Create temporary directory and copy test file
-    temp_dir = tempfile.mkdtemp()
-    test_pdf_path = Path(__file__).parent / "office_planning.pdf"
-    
-    if not test_pdf_path.exists():
-        print(f"Error: Test file not found at {test_pdf_path}")
-        return
-    
-    # Copy to temp directory with a simple name
-    temp_pdf_path = Path(temp_dir) / "office_planning.pdf"
-    shutil.copy2(test_pdf_path, temp_pdf_path)
-    
-    print(f"Test file copied to: {temp_pdf_path}")
-    
-    try:
-        # Test parameters
-        check_name = "保管スペース確保"
-        check_description = "指定エリア内に整理保管され、避難経路を塞いでいない"
-        
-        print(f"\nTesting with:")
-        print(f"  Check Name: {check_name}")
-        print(f"  Check Description: {check_description}")
-        print(f"  File: {temp_pdf_path}")
-        
-        # Mock S3 by using local file paths directly
-        # We'll modify process_review to handle local files for testing
-        result = test_process_review_local(
-            document_paths=[str(temp_pdf_path)],
-            check_name=check_name,
-            check_description=check_description,
-            language_name="日本語",
-            mcpServers=[]
-        )
-        
-        print("\n" + "="*50)
-        print("RESULT:")
-        print("="*50)
-        print(f"Status: {result.get('result', 'unknown')}")
-        print(f"Confidence: {result.get('confidence', 0)}")
-        print(f"Explanation: {result.get('explanation', 'No explanation')}")
-        print(f"Short Explanation: {result.get('shortExplanation', 'No short explanation')}")
-        
-        if 'extractedText' in result:
-            print(f"\nExtracted Text (Citations):")
-            print("-" * 30)
-            print(result['extractedText'])
-        
-        if 'reviewMeta' in result:
-            meta = result['reviewMeta']
-            print(f"\nToken Usage:")
-            print(f"  Input: {meta.get('input_tokens', 0)}")
-            print(f"  Output: {meta.get('output_tokens', 0)}")
-            print(f"  Cost: ${meta.get('total_cost', 0):.6f}")
-        
-        # Assertions for pytest
-        assert result.get('result') in ['pass', 'fail']
-        assert 0 <= result.get('confidence', 0) <= 1
-        assert result.get('explanation', '') != ''
-        
-    except Exception as e:
-        print(f"Error during test: {e}")
-        import traceback
-        traceback.print_exc()
-        raise
-    
-    finally:
-        # Cleanup
-        shutil.rmtree(temp_dir)
-        print(f"\nCleaned up temp directory: {temp_dir}")
+# A registered model that supports the document block + citations.
+CITATION_MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+# An unregistered model falls back to _DEFAULT_CONFIG (no document block).
+UNKNOWN_MODEL_ID = "example.unknown-model-v1"
 
-def test_process_review_local(document_paths, check_name, check_description, language_name, mcpServers):
-    """Modified process_review for local testing without S3"""
-    from agent import (
-        get_document_review_prompt, 
-        _run_strands_agent_with_citations, 
-        _run_strands_agent_legacy,
-        supports_citations,
-        ENABLE_CITATIONS,
-        DOCUMENT_MODEL_ID,
-        IMAGE_MODEL_ID,
-        IMAGE_FILE_EXTENSIONS
+
+# ---------------------------------------------------------------------------
+# _should_use_document_block: citation routing
+# ---------------------------------------------------------------------------
+
+
+def test_document_block_used_for_pdf_when_citations_enabled(monkeypatch):
+    """PDF + citations enabled + capable model -> document block path."""
+    monkeypatch.setattr(agent, "ENABLE_CITATIONS", True)
+    assert (
+        _should_use_document_block(["/tmp/a.pdf"], CITATION_MODEL_ID, has_images=False)
+        is True
     )
-    from strands_tools import file_read, image_reader
-    import logging
-    
-    # Setup logging
-    logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger(__name__)
-    
-    logger.info(f"Testing with {len(document_paths)} files")
-    
-    # Check file types
-    has_images = False
-    for path in document_paths:
-        ext = os.path.splitext(path)[1].lower()
-        if ext in IMAGE_FILE_EXTENSIONS:
-            has_images = True
-            break
-    
-    # Select model and prompt
-    if has_images:
-        selected_model_id = IMAGE_MODEL_ID
-        from agent import get_image_review_prompt
-        prompt = get_image_review_prompt(
-            language_name, check_name, check_description, selected_model_id
-        )
-        tools = [file_read, image_reader]
-        use_citations = False
-    else:
-        selected_model_id = DOCUMENT_MODEL_ID
-        use_citations = ENABLE_CITATIONS and supports_citations(selected_model_id)
-        
-        prompt = get_document_review_prompt(
-            language_name, check_name, check_description, use_citations=use_citations
-        )
-        tools = [file_read]
-    
-    logger.info(f"Using model: {selected_model_id}")
-    logger.info(f"Citations enabled: {use_citations}")
-    
-    # System prompt
-    system_prompt = f"You are an expert document reviewer. Analyze the provided files and evaluate the check item. All responses must be in {language_name}."
-    
-    # Run agent
-    if use_citations:
-        result = _run_strands_agent_with_citations(
-            prompt=prompt,
-            file_paths=document_paths,
-            model_id=selected_model_id,
-            system_prompt=system_prompt,
-            mcpServers=mcpServers,
-        )
-    else:
-        result = _run_strands_agent_legacy(
-            prompt=prompt,
-            file_paths=document_paths,
-            model_id=selected_model_id,
-            system_prompt=system_prompt,
-            base_tools=tools,
-            mcpServers=mcpServers,
-        )
-    
-    # Add missing fields
-    if "result" not in result:
-        result["result"] = "fail"
-    if "confidence" not in result:
-        result["confidence"] = 0.5
-    if "explanation" not in result:
-        result["explanation"] = "No explanation provided"
-    if "shortExplanation" not in result:
-        result["shortExplanation"] = "No short explanation provided"
-    if "verificationDetails" not in result:
-        result["verificationDetails"] = {"sourcesDetails": []}
-    
-    if has_images:
-        result["reviewType"] = "IMAGE"
-        if "usedImageIndexes" not in result:
-            result["usedImageIndexes"] = []
-        if "boundingBoxes" not in result:
-            result["boundingBoxes"] = []
-    else:
-        result["reviewType"] = "PDF"
-        if "extractedText" not in result:
-            result["extractedText"] = ""
-        if "pageNumber" not in result:
-            result["pageNumber"] = 1
-    
-    return result
+
+
+def test_file_read_used_when_citations_disabled(monkeypatch):
+    """ENABLE_CITATIONS=false falls back to the file_read tool path."""
+    monkeypatch.setattr(agent, "ENABLE_CITATIONS", False)
+    assert (
+        _should_use_document_block(["/tmp/a.pdf"], CITATION_MODEL_ID, has_images=False)
+        is False
+    )
+
+
+def test_file_read_used_for_images(monkeypatch):
+    """Images always use the file_read/image_reader path, regardless of the flag."""
+    monkeypatch.setattr(agent, "ENABLE_CITATIONS", True)
+    assert (
+        _should_use_document_block(["/tmp/a.png"], CITATION_MODEL_ID, has_images=True)
+        is False
+    )
+
+
+def test_file_read_used_for_unknown_model(monkeypatch):
+    """Unknown models fall back to defaults without document block support."""
+    monkeypatch.setattr(agent, "ENABLE_CITATIONS", True)
+    assert (
+        _should_use_document_block(["/tmp/a.pdf"], UNKNOWN_MODEL_ID, has_images=False)
+        is False
+    )
+
+
+def test_default_model_supports_citation():
+    """The default model supports the document block and citations."""
+    config = ModelConfig.create(CITATION_MODEL_ID)
+    assert config.supports_document_block is True
+    assert config.supports_citation is True
+
+
+# ---------------------------------------------------------------------------
+# _extract_citations_text: citations parsing from the JSON response
+# ---------------------------------------------------------------------------
+
+
+def _message_with_text(text: str) -> dict:
+    """Build an AgentResult.message-shaped dict with a single text block."""
+    return {"content": [{"text": text}]}
+
+
+def test_extract_citations_returns_array():
+    """A citations array in the marker JSON is returned as-is."""
+    message = _message_with_text(
+        '<<JSON_START>>{"result": "pass",'
+        ' "citations": ["p.3 保管スペース", "p.5 避難経路"]}<<JSON_END>>'
+    )
+    assert _extract_citations_text(message) == ["p.3 保管スペース", "p.5 避難経路"]
+
+
+def test_extract_citations_empty_when_absent():
+    """JSON without a citations field yields an empty list."""
+    message = _message_with_text('<<JSON_START>>{"result": "pass"}<<JSON_END>>')
+    assert _extract_citations_text(message) == []
+
+
+def test_extract_citations_empty_on_non_json():
+    """Non-JSON output yields an empty list instead of raising."""
+    assert _extract_citations_text(_message_with_text("no json here")) == []
+
+
+# ---------------------------------------------------------------------------
+# Opt-in Bedrock integration test (real API call, requires AWS credentials)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_BEDROCK_INTEGRATION") != "1",
+    reason="Set RUN_BEDROCK_INTEGRATION=1 to run the live Bedrock integration test",
+)
+def test_citation_review_integration():
+    """Run a real review over the bundled sample PDF via the citations path."""
+    test_pdf = Path(__file__).parent / "office_planning.pdf"
+    assert test_pdf.exists(), f"Test file not found: {test_pdf}"
+
+    from agent import process_review_from_local
+
+    result = process_review_from_local(
+        document_paths=[str(test_pdf)],
+        check_name="保管スペース確保",
+        check_description="指定エリア内に整理保管され、避難経路を塞いでいない",
+        language_name="日本語",
+    )
+
+    assert result.get("result") in ["pass", "fail"]
+    assert 0 <= result.get("confidence", 0) <= 1
+    assert result.get("explanation", "") != ""
+    assert result.get("reviewType") == "PDF"
+
 
 if __name__ == "__main__":
-    test_citation_functionality()
+    os.environ["RUN_BEDROCK_INTEGRATION"] = "1"
+    test_citation_review_integration()
+    print("Integration test passed")

--- a/review-item-processor/tests/test_prompt_caching.py
+++ b/review-item-processor/tests/test_prompt_caching.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Tests for document/image prompt caching (auto cache strategy).
+"""
+
+import os
+import sys
+
+# Add parent directory to path (same convention as the other suites).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import agent
+from strands.models import BedrockModel
+from strands.models.model import CacheConfig
+from strands.types.content import Messages
+
+
+def test_apply_cache_config_uses_auto_strategy():
+    cfg = {"model_id": "global.anthropic.claude-sonnet-4-6"}
+    agent._apply_cache_config(cfg)
+
+    assert isinstance(cfg["cache_config"], CacheConfig)
+    assert cfg["cache_config"].strategy == "auto"
+    assert cfg["cache_tools"] == "default"
+    assert "cache_prompt" not in cfg  # deprecated key no longer used
+
+
+def test_supports_caching_gates_cache_config():
+    """Unregistered models fall back to no caching (fail-safe)."""
+    assert agent.supports_caching("global.anthropic.claude-sonnet-4-6") is True
+    assert agent.supports_caching("some.unregistered.model-id") is False
+
+
+def test_bedrock_auto_strategy_caches_after_document_block():
+    """SDK contract: cache_config=auto puts the cachePoint AFTER a document, so
+    the document ends up inside the cached prefix."""
+    model = BedrockModel(
+        model_id="global.anthropic.claude-sonnet-4-6",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    messages: Messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "document": {
+                        "name": "review_doc",
+                        "format": "pdf",
+                        "source": {"bytes": b"%PDF-1.4 fake pdf bytes"},
+                    }
+                },
+                {"text": "Evaluate this document against the check item."},
+            ],
+        }
+    ]
+
+    formatted = model._format_bedrock_messages(messages)
+
+    content = formatted[0]["content"]
+    cache_idxs = [i for i, b in enumerate(content) if "cachePoint" in b]
+    doc_idxs = [i for i, b in enumerate(content) if "document" in b]
+
+    assert cache_idxs, "auto strategy must inject a cachePoint"
+    assert doc_idxs, "document block should be preserved"
+    assert max(doc_idxs) < max(cache_idxs)  # doc must precede the cache point

--- a/review-item-processor/uv.lock
+++ b/review-item-processor/uv.lock
@@ -2184,6 +2184,42 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2267,7 +2303,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "reportlab", marker = "extra == 'evals'", specifier = ">=4.4.9" },
     { name = "scikit-learn", marker = "extra == 'evals'", specifier = ">=1.3.0" },
-    { name = "strands-agents", specifier = ">=1.15.0" },
+    { name = "strands-agents", specifier = ">=1.30.0" },
     { name = "strands-agents-evals", marker = "extra == 'evals'", specifier = ">=0.1.2" },
     { name = "strands-agents-tools", extras = ["agent-core-code-interpreter"], specifier = ">=0.2.14" },
     { name = "tabulate", marker = "extra == 'evals'", specifier = ">=0.9.0" },
@@ -2528,24 +2564,26 @@ wheels = [
 
 [[package]]
 name = "strands-agents"
-version = "1.15.0"
+version = "1.52.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
     { name = "docstring-parser" },
+    { name = "httpx" },
     { name = "jsonschema" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation-threading" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/14/fee14885617d82fe6d0dc8475426fd1293632718604a97fbe070e50446c1/strands_agents-1.15.0.tar.gz", hash = "sha256:bc02d80d2ccd4964a41b26ca40eb9af35893623d2db2266eb578112374ca287a", size = 502556, upload-time = "2025-11-04T18:25:30.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/f5/7bcd5018b80dcc9eb70bb315ad42d0e8e1607473689a246bdbb763433f5a/strands_agents-1.52.0.tar.gz", hash = "sha256:e79f08527cf3b03ace3ead081f71ee43ee33de7285a4faa9ecafaef4618afeb0", size = 1333918, upload-time = "2026-08-12T18:52:03.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/0a/a551440b6184b883582f90491e86981a6d44df9cc9e45e36c0dcb04c9789/strands_agents-1.15.0-py3-none-any.whl", hash = "sha256:0c24b568dbecf1c68952ca6f44730ab95a82f5d00cd17bf4569450eae1325711", size = 249686, upload-time = "2025-11-04T18:25:28.802Z" },
+    { url = "https://files.pythonhosted.org/packages/32/28/6b1733dfb50ccf2b250d892ff9fdb0c987d0486febaf1305c5b6a904154b/strands_agents-1.52.0-py3-none-any.whl", hash = "sha256:768ff0e865df9f18154a2111f71e0c7683b8505e897704b89981cf7f11667bee", size = 687868, upload-time = "2026-08-12T18:52:01.538Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Use the Strands auto cache strategy so the document/image content 

Also fix test_citation.py to the current agent API and skip the S3-dependent MCP test when no bucket is configured.