### PR TITLE
fix(deploy): drop 'npm install -g npm@latest' that breaks CodeBuild o…

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -239,7 +239,8 @@ Resources:
                 },
                 "on-failure": "ABORT",
                 "commands": [
-                  "npm install -g npm@latest"
+                  "node --version",
+                  "npm --version"
                 ]
               },
               "build": {

--- a/deploy.yml
+++ b/deploy.yml
@@ -235,13 +235,9 @@ Resources:
             "phases": {
               "install": {
                 "runtime-versions": {
-                  "nodejs": "20"
+                  "nodejs": "24"
                 },
-                "on-failure": "ABORT",
-                "commands": [
-                  "node --version",
-                  "npm --version"
-                ]
+                "on-failure": "ABORT"
               },
               "build": {
                 "commands": [


### PR DESCRIPTION
#313 の不具合の修正

## 変更内容

CodeBuild のビルド環境に使う Docker イメージ `aws/codebuild/amazonlinux-aarch64-standard:3.0` は Node.js 20.20.1、 npm 10.8.2 であり、こちらで動作可能のため`deploy.yml` のインライン buildspec から `npm install -g npm@latest` を削除
※ `npm install -g npm@11` へのピン留めでも解決するが、バージョンが固定されていない参照を残さない方針としている

また、今後のデバッグ用に Node.js と npm のバージョン出力を追加

```diff
                 "commands": [
-                  "npm install -g npm@latest"
+                  "node --version",
+                  "npm --version"
                 ]
```

## 補足
念の為、us-west-2 と ap-northeast-1 の両方で動作確認済
